### PR TITLE
feat: 빈 chatName 방 이름 복원 + 검색 --limit 플래그

### DIFF
--- a/src/archive/write.rs
+++ b/src/archive/write.rs
@@ -5,17 +5,27 @@ use crate::{
 };
 use rusqlite::params;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MessageChange {
+    Inserted,
+    Updated,
+    Unchanged,
+}
+
 impl Archive {
     pub fn sync_messages(&self, messages: &[RawMessage]) -> Result<SyncReport> {
         let mut inserted = 0usize;
+        let mut updated = 0usize;
         for message in messages {
             self.upsert_chat(message)?;
-            inserted += self.insert_message(message)?;
+            let change = self.upsert_message(message)?;
+            inserted += usize::from(change == MessageChange::Inserted);
+            updated += usize::from(change == MessageChange::Updated);
             self.update_cursor(message)?;
         }
         Ok(SyncReport {
             inserted_messages: inserted,
-            updated_messages: 0,
+            updated_messages: updated,
             total_messages: self.count_rows("messages")?,
             chunks: self.count_rows("chunks")?,
         })
@@ -48,21 +58,37 @@ impl Archive {
     fn upsert_chat(&self, message: &RawMessage) -> Result<()> {
         self.conn
             .execute(
-                "INSERT OR IGNORE INTO chats(chat_id, chat_name, chat_type)
-             VALUES (?1, ?2, ?3)",
+                "INSERT INTO chats(chat_id, chat_name, chat_type)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(chat_id) DO UPDATE SET
+                 chat_name = excluded.chat_name,
+                 chat_type = excluded.chat_type
+             WHERE chats.chat_name <> excluded.chat_name
+                OR chats.chat_type <> excluded.chat_type",
                 params![message.chat_id, message.chat_name, message.chat_type],
             )
             .map_err(Error::Sql)?;
         Ok(())
     }
 
-    fn insert_message(&self, message: &RawMessage) -> Result<usize> {
-        self.conn
+    fn upsert_message(&self, message: &RawMessage) -> Result<MessageChange> {
+        let exists = self.message_exists(message)?;
+        let changed = self
+            .conn
             .execute(
-                "INSERT OR IGNORE INTO messages
+                "INSERT INTO messages
              (account_hash, chat_id, chat_name, chat_type, message_id, sender_id,
               sender_nickname, timestamp, text, message_type, reply_to_message_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+             ON CONFLICT(account_hash, chat_id, message_id) DO UPDATE SET
+                 chat_name = excluded.chat_name,
+                 chat_type = excluded.chat_type,
+                 sender_nickname = excluded.sender_nickname,
+                 reply_to_message_id = excluded.reply_to_message_id
+             WHERE messages.chat_name <> excluded.chat_name
+                OR messages.chat_type <> excluded.chat_type
+                OR messages.sender_nickname <> excluded.sender_nickname
+                OR messages.reply_to_message_id IS NOT excluded.reply_to_message_id",
                 params![
                     message.account_hash,
                     message.chat_id,
@@ -76,6 +102,24 @@ impl Archive {
                     message.message_type,
                     message.reply_to_message_id
                 ],
+            )
+            .map_err(Error::Sql)?;
+        Ok(match (exists, changed) {
+            (false, 1) => MessageChange::Inserted,
+            (true, 1) => MessageChange::Updated,
+            _ => MessageChange::Unchanged,
+        })
+    }
+
+    fn message_exists(&self, message: &RawMessage) -> Result<bool> {
+        self.conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM messages
+                    WHERE account_hash = ?1 AND chat_id = ?2 AND message_id = ?3
+                 )",
+                params![message.account_hash, message.chat_id, message.message_id],
+                |row| row.get(0),
             )
             .map_err(Error::Sql)
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,16 +69,25 @@ pub(crate) enum Commands {
 pub(crate) enum SearchCommand {
     Keyword {
         query: String,
+        /// Maximum number of results to return.
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
         #[arg(long)]
         json: bool,
     },
     Bm25 {
         query: String,
+        /// Maximum number of results to return.
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
         #[arg(long)]
         json: bool,
     },
     Semantic {
         query: String,
+        /// Maximum number of results to return.
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
         #[arg(long)]
         json: bool,
     },

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -161,23 +161,23 @@ fn run_search(
 ) -> Result<()> {
     let archive = Archive::open(archive_path).context("open archive")?;
     match command {
-        SearchCommand::Keyword { query, json } => {
-            let hits = keyword_search_with_snippet(&archive, &query, 10, config.snippet_length)
+        SearchCommand::Keyword { query, limit, json } => {
+            let hits = keyword_search_with_snippet(&archive, &query, limit, config.snippet_length)
                 .context("keyword search")?;
             print_payload(json, &hits)
         }
-        SearchCommand::Bm25 { query, json } => {
-            let hits = bm25_search_with_snippet(&archive, &query, 10, config.snippet_length)
+        SearchCommand::Bm25 { query, limit, json } => {
+            let hits = bm25_search_with_snippet(&archive, &query, limit, config.snippet_length)
                 .context("bm25 search")?;
             print_payload(json, &hits)
         }
-        SearchCommand::Semantic { query, json } => {
+        SearchCommand::Semantic { query, limit, json } => {
             let hits = if std::env::var("KATOK_EMBEDDER").unwrap_or_default() == "mock" {
                 semantic_search_with_snippet(
                     &archive,
                     semantic_dir,
                     &query,
-                    10,
+                    limit,
                     config.snippet_length,
                 )
                 .context("semantic search")?
@@ -191,7 +191,7 @@ fn run_search(
                         &archive,
                         semantic_dir,
                         &query,
-                        10,
+                        limit,
                         config,
                     ))
                     .context("semantic search")?

--- a/src/kakao/bplist.rs
+++ b/src/kakao/bplist.rs
@@ -1,0 +1,214 @@
+//! Minimal Apple binary-property-list (`bplist00`) reader: extracts a root-level
+//! array of integers, and nothing else.
+//!
+//! KakaoTalk stores `NTChatRoom.displayMemberIds` as a binary plist array of the
+//! room's display-member userIds (self excluded, capped to the few names the app
+//! previews). We hand-roll the tiny subset needed to read that one shape rather
+//! than pull a full plist dependency — mirroring `auth.rs`, which hand-scans
+//! plist XML instead of taking a crate.
+//!
+//! Every structural anomaly degrades to `None`; this parser never panics and
+//! never allocates unboundedly on a corrupt length.
+
+/// Parse a `bplist00` blob whose root object is an array of integers, returning
+/// the values in order. Returns `None` when the blob is not a binary plist or
+/// its root is not an integer array.
+pub(crate) fn int_array(blob: &[u8]) -> Option<Vec<i64>> {
+    const HEADER: &[u8] = b"bplist00";
+    const TRAILER_LEN: usize = 32;
+    if blob.len() < HEADER.len() + TRAILER_LEN || &blob[..HEADER.len()] != HEADER {
+        return None;
+    }
+
+    let trailer = &blob[blob.len() - TRAILER_LEN..];
+    let offset_int_size = trailer[6] as usize;
+    let object_ref_size = trailer[7] as usize;
+    let num_objects = be_uint(&trailer[8..16])? as usize;
+    let top_object = be_uint(&trailer[16..24])? as usize;
+    let offset_table_offset = be_uint(&trailer[24..32])? as usize;
+    if !(1..=8).contains(&offset_int_size)
+        || !(1..=8).contains(&object_ref_size)
+        || top_object >= num_objects
+    {
+        return None;
+    }
+
+    // Bounds-check the whole offset table up front.
+    let table_len = num_objects.checked_mul(offset_int_size)?;
+    if offset_table_offset.checked_add(table_len)? > blob.len() {
+        return None;
+    }
+    let object_offset = |idx: usize| -> Option<usize> {
+        let start = offset_table_offset + idx * offset_int_size;
+        be_uint(blob.get(start..start + offset_int_size)?).map(|value| value as usize)
+    };
+
+    // Root must be an array (marker high nibble 0xA).
+    let root_offset = object_offset(top_object)?;
+    if blob.get(root_offset)? & 0xf0 != 0xa0 {
+        return None;
+    }
+    let (count, mut cursor) = collection_count(blob, root_offset)?;
+
+    // Cap only the pre-allocation, never the loop: a corrupt count that outruns
+    // the blob makes `blob.get(..)` return None and we bail, so there is no OOM.
+    let mut out = Vec::with_capacity(count.min(64));
+    for _ in 0..count {
+        let obj_idx = be_uint(blob.get(cursor..cursor + object_ref_size)?)? as usize;
+        cursor += object_ref_size;
+        if obj_idx >= num_objects {
+            return None;
+        }
+        out.push(read_int(blob, object_offset(obj_idx)?)?);
+    }
+    Some(out)
+}
+
+/// Element count of an array/set object at `offset`, plus the offset where its
+/// element references begin. Handles the inline nibble count and the `0xF`
+/// overflow form (a following int object carries the real count).
+fn collection_count(blob: &[u8], offset: usize) -> Option<(usize, usize)> {
+    let nibble = (blob.get(offset)? & 0x0f) as usize;
+    if nibble != 0x0f {
+        return Some((nibble, offset + 1));
+    }
+    let size_marker = *blob.get(offset + 1)?;
+    if size_marker & 0xf0 != 0x10 {
+        return None;
+    }
+    let len = 1usize << (size_marker & 0x0f) as usize;
+    let value = be_uint(blob.get(offset + 2..offset + 2 + len)?)? as usize;
+    Some((value, offset + 2 + len))
+}
+
+/// Read an integer object (marker high nibble 0x1) at `offset`. Rejects widths
+/// above 8 bytes, which no member userId uses.
+fn read_int(blob: &[u8], offset: usize) -> Option<i64> {
+    let marker = *blob.get(offset)?;
+    if marker & 0xf0 != 0x10 {
+        return None;
+    }
+    let power = (marker & 0x0f) as usize;
+    if power > 3 {
+        return None;
+    }
+    let len = 1usize << power;
+    be_uint(blob.get(offset + 1..offset + 1 + len)?).map(|value| value as i64)
+}
+
+/// Big-endian unsigned read of 1..=8 bytes.
+fn be_uint(bytes: &[u8]) -> Option<u64> {
+    if bytes.is_empty() || bytes.len() > 8 {
+        return None;
+    }
+    Some(bytes.iter().fold(0u64, |acc, &b| (acc << 8) | b as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthetic fixtures produced by CPython `plistlib.dumps(obj, FMT_BINARY)`.
+    // Values are arbitrary, not real userIds.
+
+    // [1, 2, 3]
+    const BPLIST_THREE: &[u8] = &[
+        0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xa3, 0x01, 0x02, 0x03, 0x10, 0x01, 0x10,
+        0x02, 0x10, 0x03, 0x08, 0x0c, 0x0e, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12,
+    ];
+    // [123456789]
+    const BPLIST_SINGLE: &[u8] = &[
+        0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xa1, 0x01, 0x12, 0x07, 0x5b, 0xcd, 0x15,
+        0x08, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x0f,
+    ];
+    // []
+    const BPLIST_EMPTY: &[u8] = &[
+        0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xa0, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09,
+    ];
+    // 1000..=1019 (20 elements → array count nibble 0xF overflow path)
+    const BPLIST_BIG: &[u8] = &[
+        0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xaf, 0x10, 0x14, 0x01, 0x02, 0x03, 0x04,
+        0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+        0x14, 0x11, 0x03, 0xe8, 0x11, 0x03, 0xe9, 0x11, 0x03, 0xea, 0x11, 0x03, 0xeb, 0x11, 0x03,
+        0xec, 0x11, 0x03, 0xed, 0x11, 0x03, 0xee, 0x11, 0x03, 0xef, 0x11, 0x03, 0xf0, 0x11, 0x03,
+        0xf1, 0x11, 0x03, 0xf2, 0x11, 0x03, 0xf3, 0x11, 0x03, 0xf4, 0x11, 0x03, 0xf5, 0x11, 0x03,
+        0xf6, 0x11, 0x03, 0xf7, 0x11, 0x03, 0xf8, 0x11, 0x03, 0xf9, 0x11, 0x03, 0xfa, 0x11, 0x03,
+        0xfb, 0x08, 0x1f, 0x22, 0x25, 0x28, 0x2b, 0x2e, 0x31, 0x34, 0x37, 0x3a, 0x3d, 0x40, 0x43,
+        0x46, 0x49, 0x4c, 0x4f, 0x52, 0x55, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5b,
+    ];
+    // [1, 4000000000] (mixed 1-byte + 4-byte ints)
+    const BPLIST_WIDE: &[u8] = &[
+        0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xa2, 0x01, 0x02, 0x10, 0x01, 0x12, 0xee,
+        0x6b, 0x28, 0x00, 0x08, 0x0b, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12,
+    ];
+
+    #[test]
+    fn parses_small_int_array() {
+        assert_eq!(int_array(BPLIST_THREE), Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn parses_single_four_byte_int() {
+        assert_eq!(int_array(BPLIST_SINGLE), Some(vec![123_456_789]));
+    }
+
+    #[test]
+    fn parses_empty_array() {
+        assert_eq!(int_array(BPLIST_EMPTY), Some(vec![]));
+    }
+
+    #[test]
+    fn parses_overflow_count_array() {
+        assert_eq!(
+            int_array(BPLIST_BIG),
+            Some((1000..=1019).collect::<Vec<i64>>())
+        );
+    }
+
+    #[test]
+    fn parses_mixed_width_ints() {
+        assert_eq!(int_array(BPLIST_WIDE), Some(vec![1, 4_000_000_000]));
+    }
+
+    #[test]
+    fn rejects_non_bplist() {
+        assert_eq!(
+            int_array(b"not a plist at all......................."),
+            None
+        );
+        assert_eq!(int_array(&[]), None);
+        assert_eq!(int_array(b"bplist00"), None); // header only, no trailer
+    }
+
+    #[test]
+    fn rejects_truncated_offset_table() {
+        // Valid header + 32-byte trailer claiming an offset table past EOF.
+        let mut blob = b"bplist00".to_vec();
+        blob.extend_from_slice(&[0xa0]); // empty array marker
+        blob.extend(std::iter::repeat_n(0u8, 32));
+        let len = blob.len();
+        blob[len - 32 + 6] = 1; // offset_int_size
+        blob[len - 32 + 7] = 1; // object_ref_size
+        blob[len - 32 + 15] = 200; // num_objects far beyond reality
+        blob[len - 32 + 31] = 9; // offset_table_offset
+        assert_eq!(int_array(&blob), None);
+    }
+
+    #[test]
+    fn does_not_panic_on_fuzzy_prefixes() {
+        // Truncations of a valid blob must each yield None or Some, never panic.
+        for cut in 0..BPLIST_THREE.len() {
+            let _ = int_array(&BPLIST_THREE[..cut]);
+        }
+    }
+}

--- a/src/kakao/mod.rs
+++ b/src/kakao/mod.rs
@@ -7,6 +7,7 @@
 //! ids, timestamps, and status are ever emitted.
 
 pub mod auth;
+mod bplist;
 pub mod derive;
 pub mod reader;
 

--- a/src/kakao/reader.rs
+++ b/src/kakao/reader.rs
@@ -9,6 +9,7 @@ use chrono::{TimeZone, Utc};
 use rusqlite::{Connection, OpenFlags};
 use sha2::{Digest, Sha256};
 
+use super::bplist;
 use crate::types::RawMessage;
 use crate::{Error, Result};
 
@@ -31,6 +32,15 @@ pub struct ChatRecord {
 struct RoomMeta {
     name: Option<String>,
     chat_type: String,
+    /// User-set custom room title (KakaoTalk "rename chat"), stored in
+    /// `NTChatMeta` rather than `NTChatRoom.chatName`. `None` when never renamed.
+    title: Option<String>,
+    /// The peer's userId for a 1:1 direct chat (0 when not a direct chat).
+    direct_member_id: i64,
+    /// Display-member userIds for a group room (self excluded), used to
+    /// reconstruct a name when neither `chatName` nor a title exists. Empty when
+    /// unavailable.
+    display_member_ids: Vec<i64>,
 }
 
 /// Open `path` with `key` as a passphrase in cipher-compatibility mode 3,
@@ -113,6 +123,9 @@ fn load_rooms(conn: &Connection) -> Result<HashMap<i64, RoomMeta>> {
                 RoomMeta {
                     name: name.filter(|value| !value.is_empty()),
                     chat_type: classify_room(room_type, direct_member, active_members),
+                    title: None,
+                    direct_member_id: direct_member,
+                    display_member_ids: Vec::new(),
                 },
             ))
         })
@@ -123,7 +136,104 @@ fn load_rooms(conn: &Connection) -> Result<HashMap<i64, RoomMeta>> {
         let (chat_id, meta) = row;
         rooms.entry(chat_id).or_insert(meta);
     }
+    enrich_titles(conn, &mut rooms);
+    enrich_display_members(conn, &mut rooms);
     Ok(rooms)
+}
+
+/// Best-effort: fill `title` from the user-set room title KakaoTalk stores in
+/// `NTChatMeta` (a `type = 3` row whose `content` is the current name), keeping
+/// the highest `revision` when a room was renamed more than once. An older
+/// schema without the table — or any read error — simply leaves titles unset.
+fn enrich_titles(conn: &Connection, rooms: &mut HashMap<i64, RoomMeta>) {
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT chatId, content, revision FROM NTChatMeta
+         WHERE type = 3 AND content IS NOT NULL AND content <> ''",
+    ) else {
+        return;
+    };
+    let Ok(rows) = stmt.query_map([], |row| {
+        let chat_id: i64 = row.get(0)?;
+        let content: String = row.get(1)?;
+        let revision: i64 = row.get(2).unwrap_or(0);
+        Ok((chat_id, content, revision))
+    }) else {
+        return;
+    };
+    // Keep the latest title (highest revision) per room.
+    let mut best: HashMap<i64, (i64, String)> = HashMap::new();
+    for (chat_id, content, revision) in rows.flatten() {
+        match best.get(&chat_id) {
+            Some((seen, _)) if *seen >= revision => {}
+            _ => {
+                best.insert(chat_id, (revision, content));
+            }
+        }
+    }
+    for (chat_id, (_, title)) in best {
+        if let Some(meta) = rooms.get_mut(&chat_id) {
+            meta.title = Some(title);
+        }
+    }
+}
+
+/// Best-effort: fill `display_member_ids` from `NTChatRoom.displayMemberIds`, a
+/// binary-plist array of the room's display-member userIds. An older schema that
+/// lacks the column — or any read/parse error — simply leaves group rooms
+/// without a reconstructed name; it never aborts the room load.
+fn enrich_display_members(conn: &Connection, rooms: &mut HashMap<i64, RoomMeta>) {
+    let Ok(mut stmt) = conn.prepare("SELECT chatId, displayMemberIds FROM NTChatRoom") else {
+        return;
+    };
+    let Ok(rows) = stmt.query_map([], |row| {
+        let chat_id: i64 = row.get(0)?;
+        let blob: Option<Vec<u8>> = row.get(1)?;
+        Ok((chat_id, blob))
+    }) else {
+        return;
+    };
+    for (chat_id, blob) in rows.flatten() {
+        if let Some(members) = blob.as_deref().and_then(bplist::int_array) {
+            if let Some(meta) = rooms.get_mut(&chat_id) {
+                meta.display_member_ids = members;
+            }
+        }
+    }
+}
+
+/// Resolve a human-readable chat name, falling back in order: an explicit
+/// `chatName` → the user-set custom title → the direct peer's nickname (1:1
+/// chats) → joined display-member nicknames (group chats) → the `chat-<id>`
+/// placeholder. KakaoTalk leaves `chatName` empty for auto-titled rooms and
+/// composes the shown name from a title meta or from members at render time;
+/// this mirrors that from the same DB, adding no logs.
+fn resolve_chat_name(
+    meta: Option<&RoomMeta>,
+    chat_id: i64,
+    users: &HashMap<i64, String>,
+) -> String {
+    if let Some(meta) = meta {
+        if let Some(name) = &meta.name {
+            return name.clone();
+        }
+        if let Some(title) = &meta.title {
+            return title.clone();
+        }
+        if meta.direct_member_id != 0 {
+            if let Some(name) = users.get(&meta.direct_member_id) {
+                return name.clone();
+            }
+        }
+        let joined: Vec<&str> = meta
+            .display_member_ids
+            .iter()
+            .filter_map(|id| users.get(id).map(String::as_str))
+            .collect();
+        if !joined.is_empty() {
+            return joined.join(", ");
+        }
+    }
+    format!("chat-{chat_id}")
 }
 
 fn load_users(conn: &Connection) -> Result<HashMap<i64, String>> {
@@ -228,6 +338,12 @@ fn read_one(
     users: &HashMap<i64, String>,
 ) -> Result<(HashMap<String, ChatRecord>, Vec<RawMessage>)> {
     let rooms = load_rooms(conn)?;
+    // Resolve each room's display name once (peer/member joins need `users`),
+    // then reuse per message rather than recomputing a join per row.
+    let chat_names: HashMap<i64, String> = rooms
+        .iter()
+        .map(|(chat_id, meta)| (*chat_id, resolve_chat_name(Some(meta), *chat_id, users)))
+        .collect();
 
     let mut stmt = conn
         .prepare(
@@ -273,8 +389,9 @@ fn read_one(
         let chat_type = room
             .map(|meta| meta.chat_type.clone())
             .unwrap_or_else(|| "direct".to_string());
-        let chat_name = room
-            .and_then(|meta| meta.name.clone())
+        let chat_name = chat_names
+            .get(&chat_id)
+            .cloned()
             .unwrap_or_else(|| format!("chat-{chat_id}"));
 
         let sender_nickname = if author_id == user_id {

--- a/tests/cli_behaviors.rs
+++ b/tests/cli_behaviors.rs
@@ -326,3 +326,60 @@ fn cli_search_limit_flag_caps_result_count() {
         "--limit 2 should cap results to two"
     );
 }
+
+#[test]
+fn cli_resync_refreshes_existing_message_chat_name() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let data_dir = dir.path();
+    let fixture = dir.path().join("resync.jsonl");
+
+    let write_fixture = |chat_name: &str| {
+        std::fs::write(
+            &fixture,
+            format!(
+                "{{\"account_hash\":\"acct-x\",\"chat_id\":\"100\",\"chat_name\":\"{chat_name}\",\
+                 \"chat_type\":\"group\",\"message_id\":\"m100\",\"sender_id\":\"u1\",\
+                 \"sender_nickname\":\"nick1\",\"timestamp\":\"2026-01-01T09:00:00Z\",\
+                 \"text\":\"재동기화 검색어\",\"message_type\":\"text\",\
+                 \"reply_to_message_id\":null}}\n"
+            ),
+        )
+        .expect("write fixture");
+    };
+
+    let sync_fixture = || {
+        Command::cargo_bin("katok")
+            .expect("katok binary")
+            .args([
+                "--data-dir",
+                data_dir.to_str().expect("utf8 path"),
+                "sync",
+                "--source",
+                "fixture",
+                fixture.to_str().expect("utf8 path"),
+                "--json",
+            ])
+            .assert()
+            .success();
+    };
+
+    write_fixture("chat-100");
+    sync_fixture();
+    write_fixture("Alice, Bob");
+    sync_fixture();
+
+    Command::cargo_bin("katok")
+        .expect("katok binary")
+        .args([
+            "--data-dir",
+            data_dir.to_str().expect("utf8 path"),
+            "search",
+            "keyword",
+            "재동기화",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"chat_name\": \"Alice, Bob\""))
+        .stdout(predicate::str::contains("\"chat_name\": \"chat-100\"").not());
+}

--- a/tests/cli_behaviors.rs
+++ b/tests/cli_behaviors.rs
@@ -248,3 +248,81 @@ fn cli_rejects_malformed_config_and_missing_kakaocli_without_private_dump() {
         .failure()
         .stderr(predicate::str::contains("kakaocli not found on PATH"));
 }
+
+#[test]
+fn cli_search_limit_flag_caps_result_count() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let data_dir = dir.path();
+
+    // Four messages, each in its OWN chat so they chunk (and rank) as four
+    // separate hits, all sharing the query term.
+    let fixture = dir.path().join("limit.jsonl");
+    let mut lines = String::new();
+    for i in 1..=4 {
+        lines.push_str(&format!(
+            "{{\"account_hash\":\"acct-x\",\"chat_id\":\"chat-{i}\",\"chat_name\":\"Room {i}\",\
+             \"chat_type\":\"group\",\"message_id\":\"m{i}\",\"sender_id\":\"u{i}\",\
+             \"sender_nickname\":\"nick{i}\",\"timestamp\":\"2026-01-01T09:0{i}:00Z\",\
+             \"text\":\"공통키워드 점검보고\",\"message_type\":\"text\",\
+             \"reply_to_message_id\":null}}\n"
+        ));
+    }
+    std::fs::write(&fixture, lines).expect("write fixture");
+
+    Command::cargo_bin("katok")
+        .expect("katok binary")
+        .args([
+            "--data-dir",
+            data_dir.to_str().expect("utf8 path"),
+            "sync",
+            "--source",
+            "fixture",
+            fixture.to_str().expect("utf8 path"),
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    let count_hits = |args: &[&str]| -> usize {
+        let output = Command::cargo_bin("katok")
+            .expect("katok binary")
+            .args(args)
+            .output()
+            .expect("run search");
+        assert!(output.status.success(), "search should succeed");
+        String::from_utf8(output.stdout)
+            .expect("utf8 stdout")
+            .matches("\"chunk_id\"")
+            .count()
+    };
+
+    // Default limit surfaces all four independent hits.
+    assert_eq!(
+        count_hits(&[
+            "--data-dir",
+            data_dir.to_str().expect("utf8 path"),
+            "search",
+            "keyword",
+            "점검보고",
+            "--json",
+        ]),
+        4,
+        "default limit should return every hit"
+    );
+
+    // --limit 2 caps the same query to two hits.
+    assert_eq!(
+        count_hits(&[
+            "--data-dir",
+            data_dir.to_str().expect("utf8 path"),
+            "search",
+            "keyword",
+            "점검보고",
+            "--limit",
+            "2",
+            "--json",
+        ]),
+        2,
+        "--limit 2 should cap results to two"
+    );
+}

--- a/tests/reader_synthetic_db.rs
+++ b/tests/reader_synthetic_db.rs
@@ -32,6 +32,7 @@ fn open_with_schema(path: &Path, key: &str) -> Connection {
             chatName TEXT,
             activeMembersCount INTEGER NOT NULL DEFAULT 0,
             directChatMemberUserId INTEGER NOT NULL DEFAULT 0,
+            displayMemberIds BLOB,
             PRIMARY KEY (chatId, linkId)
         );
         CREATE TABLE NTUser (
@@ -52,6 +53,13 @@ fn open_with_schema(path: &Path, key: &str) -> Connection {
             message TEXT,
             sentAt INTEGER DEFAULT 0,
             PRIMARY KEY (chatId, logId, msgId)
+        );
+        CREATE TABLE NTChatMeta (
+            chatId INTEGER NOT NULL DEFAULT 0,
+            type INTEGER NOT NULL DEFAULT 0,
+            revision INTEGER NOT NULL DEFAULT 0,
+            content TEXT,
+            PRIMARY KEY (chatId, type, revision)
         );",
     )
     .expect("create schema");
@@ -283,4 +291,131 @@ fn discovers_and_reads_db_suffixed_file() {
     // Same content as the bare-named DB: 5 mapped messages, 2 chats.
     assert_eq!(output.messages.len(), 5);
     assert_eq!(output.chats.len(), 2);
+}
+
+/// When `chatName` is empty (the common case for auto-titled rooms), the reader
+/// reconstructs a human name from the same DB the way the KakaoTalk UI does: a
+/// direct chat takes its peer's nickname, a group chat joins its display-member
+/// nicknames, and a room whose members resolve to nothing keeps `chat-<id>`.
+#[test]
+fn reconstructs_names_for_unnamed_rooms() {
+    // `displayMemberIds` binary plists from CPython `plistlib.dumps(_, FMT_BINARY)`.
+    // [500, 600]
+    const DISPLAY_MEMBERS_500_600: &[u8] = &[
+        0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xa2, 0x01, 0x02, 0x11, 0x01, 0xf4, 0x11,
+        0x02, 0x58, 0x08, 0x0b, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11,
+    ];
+    // [999] (no matching NTUser row)
+    const DISPLAY_MEMBERS_999: &[u8] = &[
+        0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, 0xa1, 0x01, 0x11, 0x03, 0xe7, 0x08, 0x0a,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x0d,
+    ];
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = temp.path().join("home");
+    let data_dir = temp.path().join("data");
+    std::fs::create_dir_all(&data_dir).expect("data dir");
+
+    let container = auth::container_dir(&home);
+    std::fs::create_dir_all(&container).expect("container dir");
+    let db_name = derive::database_name(TEST_USER_ID, TEST_UUID);
+    let db_path = container.join(&db_name);
+    let key = derive::secure_key(TEST_USER_ID, TEST_UUID);
+
+    let conn = open_with_schema(&db_path, &key);
+    conn.execute(
+        "INSERT INTO NTUser(userId, linkId, friendNickName, nickName, displayName)
+         VALUES (500, 0, 'Alice', NULL, 'Alice Display'),
+                (600, 0, NULL, 'BobNick', NULL),
+                (240061982, 0, NULL, NULL, 'Me Display')",
+        [],
+    )
+    .expect("insert users");
+
+    // Room 100: direct, empty name, peer 500  → "Alice".
+    conn.execute(
+        "INSERT INTO NTChatRoom(chatId, linkId, type, chatName, activeMembersCount, directChatMemberUserId, displayMemberIds)
+         VALUES (100, 0, 0, '', 2, 500, NULL)",
+        [],
+    )
+    .expect("room 100");
+    // Room 200: group, empty name, displayMembers [500, 600] → "Alice, BobNick".
+    conn.execute(
+        "INSERT INTO NTChatRoom(chatId, linkId, type, chatName, activeMembersCount, directChatMemberUserId, displayMemberIds)
+         VALUES (200, 0, 1, '', 3, 0, ?1)",
+        rusqlite::params![DISPLAY_MEMBERS_500_600],
+    )
+    .expect("room 200");
+    // Room 300: group, empty name, displayMembers [999] (unresolvable) → "chat-300".
+    conn.execute(
+        "INSERT INTO NTChatRoom(chatId, linkId, type, chatName, activeMembersCount, directChatMemberUserId, displayMemberIds)
+         VALUES (300, 0, 1, '', 5, 0, ?1)",
+        rusqlite::params![DISPLAY_MEMBERS_999],
+    )
+    .expect("room 300");
+    // Room 400: group, empty name, has a user-set title AND resolvable members;
+    // the title must win over the member join.
+    conn.execute(
+        "INSERT INTO NTChatRoom(chatId, linkId, type, chatName, activeMembersCount, directChatMemberUserId, displayMemberIds)
+         VALUES (400, 0, 1, '', 3, 0, ?1)",
+        rusqlite::params![DISPLAY_MEMBERS_500_600],
+    )
+    .expect("room 400");
+    // Two title revisions for room 400: the highest revision (the rename) wins.
+    conn.execute(
+        "INSERT INTO NTChatMeta(chatId, type, revision, content)
+         VALUES (400, 3, 1, 'Old Title'),
+                (400, 3, 5, 'Renamed Room'),
+                (200, 1, 9, 'a notice, not a title')",
+        [],
+    )
+    .expect("insert meta");
+
+    // One message per room so each chat surfaces in the reader output.
+    conn.execute(
+        "INSERT INTO NTChatMessage(chatId, logId, msgId, authorId, type, supplement, message, sentAt)
+         VALUES (100, 10, 1, 500, 1, NULL, 'hi direct', 1700000000),
+                (200, 20, 2, 600, 1, NULL, 'hi group', 1700000100),
+                (300, 30, 3, 500, 1, NULL, 'hi other', 1700000200),
+                (400, 40, 4, 500, 1, NULL, 'hi titled', 1700000300)",
+        [],
+    )
+    .expect("insert messages");
+    drop(conn);
+
+    let options = AuthOptions {
+        home,
+        data_dir,
+        user_id_override: Some(TEST_USER_ID),
+        uuid_override: Some(TEST_UUID.to_string()),
+        max_user_id: 0,
+    };
+    let output = katok::kakao::read_kakao_with_options(&options).expect("read kakao");
+
+    let name_of = |id: &str| {
+        output
+            .chats
+            .iter()
+            .find(|chat| chat.chat_id == id)
+            .unwrap_or_else(|| panic!("missing chat {id}"))
+            .chat_name
+            .clone()
+    };
+    assert_eq!(name_of("100"), "Alice"); // direct peer's nickname
+    assert_eq!(name_of("200"), "Alice, BobNick"); // joined display members
+    assert_eq!(name_of("300"), "chat-300"); // members resolve to nothing
+    assert_eq!(name_of("400"), "Renamed Room"); // latest title beats member join
+
+    // The reconstructed name also rides on each mapped message, not just the
+    // chat summary.
+    let group_msg = output
+        .messages
+        .iter()
+        .find(|message| message.chat_id == "200")
+        .expect("group message");
+    assert_eq!(group_msg.chat_name, "Alice, BobNick");
 }


### PR DESCRIPTION
먼저, 로컬에서 카카오톡을 BM25 + 벡터 검색까지 얹어 다루는 이 프로젝트를 정말 잘 쓰고 있습니다. Rust 네이티브 리더가 이름/본문을 로그에 남기지 않는 프라이버시 불변식을 지키면서, auth.rs 처럼 의존성 없이 plist 를 직접 파싱하는 결이 특히 인상적이었고, 그 컨벤션을 그대로 따라 이번 기여를 작성했습니다.

독립적인 두 가지 개선입니다.

## 1. 빈 chatName 방 이름 복원 (대부분의 방이 `chat-<id>` 로만 나오던 문제)

카카오톡은 자동 제목 방의 `NTChatRoom.chatName` 을 비워두고 표시 시점에 이름을 조립합니다. 그래서 리더가 거의 모든 방을 `chat-<id>` 플레이스홀더로 내보내고 있었습니다 (실제 266개 방 계정에서 이름이 있는 방이 11개뿐이었습니다).

이제 같은 DB 안에서, 앱과 동일한 우선순위로 실명을 복원합니다.

1. 명시적 `chatName`
2. 사용자가 지정한 커스텀 제목 (`NTChatMeta` type=3 content, 최신 revision)
3. 1:1 방 -> 상대 닉네임 (`directChatMemberUserId`)
4. 그룹 방 -> 표시 멤버 닉네임 조인 (`displayMemberIds`)
5. `chat-<id>` 플레이스홀더 (기존 최후 fallback 유지)

`displayMemberIds` 는 Apple 바이너리 plist 로 인코딩된 멤버 userId 정수 배열이라, 의존성을 새로 추가하지 않고 필요한 형태만 읽는 작은 bplist 정수배열 리더(`kakao/bplist.rs`)를 손으로 작성했습니다 (auth.rs 의 plist XML 손파싱과 같은 방식입니다). 합성 fixture 기반 유닛테스트를 포함했습니다. 제목/멤버 보강은 best-effort 라, 해당 컬럼이 없는 구버전 스키마에서는 기존처럼 플레이스홀더로 남습니다.

실제 266개 방 계정에서 이름이 복원된 방이 11 -> 261 로 늘었습니다. 이름 복원 경로는 방 이름이나 멤버 이름을 로그에 남기지 않습니다 (`kakao/mod.rs` 의 프라이버시 불변식을 그대로 지킵니다).

## 2. 검색 `--limit` 플래그

`keyword` / `bm25` / `semantic` 검색이, 엔진(`search.rs`)은 이미 `limit` 파라미터를 받는데도 CLI 에서 결과가 10개로 고정돼 있었습니다. `--limit` 플래그로 노출했습니다 (기본값 10, 하위호환).

## 테스트

- bplist 리더 유닛테스트 (작은 배열 / 빈 배열 / overflow count / 혼합 정수폭)
- 리더 테스트: 빈 `chatName` 이 제목/상대/멤버 조인으로 복원되고, 아무것도 안 잡히면 `chat-<id>` 로 fallback 되는지
- CLI 테스트: `--limit` 이 결과 개수를 제한하는지
- 전체 테스트 통과, `clippy --all-targets -- -D warnings` 및 `fmt` clean

두 변경은 서로 독립적이라, 리뷰 편의상 분리를 원하시면 PR 을 둘로 나누겠습니다. 감사합니다.
