### PR TITLE
fix: 방 이름 복원·검색 --limit 견고성 보강 (#2 후속)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ katok index --json
 katok search keyword "계약서" --json
 katok search bm25 "지난주 미팅 자료" --json
 katok search semantic "최근에 논의한 세금 신고 일정" --json
+katok search bm25 "지난주 미팅 자료" --limit 30 --json
 ```
+
+각 `search` 명령은 `--limit <N>`(기본 10)으로 반환할 결과 개수를 조절할 수 있습니다.
 
 검색 최신성이 중요하면 검색 전에 항상 `katok doctor --json`의 `freshness`를 확인하세요. 이 기본 doctor는 macOS app data probe를 실행하지 않으므로 권한 prompt 없이 사용할 수 있습니다. `sync_before_search`가 `true`이면 `katok sync --source macos --json`을 먼저 실행하고, `index_before_semantic_search`가 `true`이면 `katok index --json`을 실행한 뒤 semantic search를 사용합니다.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ pub(crate) enum SearchCommand {
     Keyword {
         query: String,
         /// Maximum number of results to return.
-        #[arg(long, default_value_t = 10)]
+        #[arg(long, default_value_t = 10, value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=100_000))]
         limit: usize,
         #[arg(long)]
         json: bool,
@@ -78,7 +78,7 @@ pub(crate) enum SearchCommand {
     Bm25 {
         query: String,
         /// Maximum number of results to return.
-        #[arg(long, default_value_t = 10)]
+        #[arg(long, default_value_t = 10, value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=100_000))]
         limit: usize,
         #[arg(long)]
         json: bool,
@@ -86,7 +86,7 @@ pub(crate) enum SearchCommand {
     Semantic {
         query: String,
         /// Maximum number of results to return.
-        #[arg(long, default_value_t = 10)]
+        #[arg(long, default_value_t = 10, value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=100_000))]
         limit: usize,
         #[arg(long)]
         json: bool,

--- a/src/kakao/bplist.rs
+++ b/src/kakao/bplist.rs
@@ -16,6 +16,10 @@
 pub(crate) fn int_array(blob: &[u8]) -> Option<Vec<i64>> {
     const HEADER: &[u8] = b"bplist00";
     const TRAILER_LEN: usize = 32;
+    // A member list this long is corrupt, not real (KakaoTalk previews only a
+    // handful). Refusing it stops a local-DB fault from amplifying into a huge
+    // Vec / giant reconstructed chat name.
+    const MAX_ELEMENTS: usize = 256;
     if blob.len() < HEADER.len() + TRAILER_LEN || &blob[..HEADER.len()] != HEADER {
         return None;
     }
@@ -33,14 +37,25 @@ pub(crate) fn int_array(blob: &[u8]) -> Option<Vec<i64>> {
         return None;
     }
 
-    // Bounds-check the whole offset table up front.
+    // Layout: header | object area | offset table | trailer. The object area is
+    // [HEADER, offset_table_offset); the offset table must start after the header
+    // and end before the trailer. Anything else is malformed, not data.
+    let object_area_start = HEADER.len();
+    let content_end = blob.len() - TRAILER_LEN;
     let table_len = num_objects.checked_mul(offset_int_size)?;
-    if offset_table_offset.checked_add(table_len)? > blob.len() {
+    let table_end = offset_table_offset.checked_add(table_len)?;
+    if offset_table_offset < object_area_start || table_end > content_end {
         return None;
     }
+
+    // Resolve an object index to a byte offset, requiring it to land inside the
+    // object area (never the header, offset table, or trailer).
     let object_offset = |idx: usize| -> Option<usize> {
         let start = offset_table_offset + idx * offset_int_size;
-        be_uint(blob.get(start..start + offset_int_size)?).map(|value| value as usize)
+        let off = be_uint(blob.get(start..start + offset_int_size)?)? as usize;
+        (object_area_start..offset_table_offset)
+            .contains(&off)
+            .then_some(off)
     };
 
     // Root must be an array (marker high nibble 0xA).
@@ -49,11 +64,17 @@ pub(crate) fn int_array(blob: &[u8]) -> Option<Vec<i64>> {
         return None;
     }
     let (count, mut cursor) = collection_count(blob, root_offset)?;
+    if count > MAX_ELEMENTS {
+        return None;
+    }
 
-    // Cap only the pre-allocation, never the loop: a corrupt count that outruns
-    // the blob makes `blob.get(..)` return None and we bail, so there is no OOM.
-    let mut out = Vec::with_capacity(count.min(64));
+    let mut out = Vec::with_capacity(count);
     for _ in 0..count {
+        // Element refs are part of the array object and must stay in the object
+        // area, before the offset table.
+        if cursor.checked_add(object_ref_size)? > offset_table_offset {
+            return None;
+        }
         let obj_idx = be_uint(blob.get(cursor..cursor + object_ref_size)?)? as usize;
         cursor += object_ref_size;
         if obj_idx >= num_objects {
@@ -93,7 +114,8 @@ fn read_int(blob: &[u8], offset: usize) -> Option<i64> {
         return None;
     }
     let len = 1usize << power;
-    be_uint(blob.get(offset + 1..offset + 1 + len)?).map(|value| value as i64)
+    // Reject an 8-byte value above i64::MAX rather than wrapping it negative.
+    i64::try_from(be_uint(blob.get(offset + 1..offset + 1 + len)?)?).ok()
 }
 
 /// Big-endian unsigned read of 1..=8 bytes.
@@ -210,5 +232,41 @@ mod tests {
         for cut in 0..BPLIST_THREE.len() {
             let _ = int_array(&BPLIST_THREE[..cut]);
         }
+    }
+
+    #[test]
+    fn rejects_element_count_over_cap() {
+        // A well-formed header/trailer whose array count (via the 0xF overflow
+        // form) is 300 must be refused, not amplified. Layout: header, array
+        // marker `af` + 2-byte int 300, a 1-entry offset table, 32-byte trailer.
+        let blob: &[u8] = &[
+            0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30, // bplist00
+            0xaf, 0x11, 0x01, 0x2c, // array, overflow count int = 0x012c (300)
+            0x08, // offset table: object 0 at byte 8
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // trailer[0..6] unused
+            0x01, // offset_int_size
+            0x01, // object_ref_size
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // num_objects = 1
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // top_object = 0
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, // offset_table_offset = 12
+        ];
+        assert_eq!(int_array(blob), None);
+    }
+
+    #[test]
+    fn rejects_object_offset_into_trailer() {
+        // Corrupt a valid blob so its single offset-table entry points into the
+        // trailer instead of the object area. Must degrade to None.
+        let mut blob = BPLIST_SINGLE.to_vec();
+        let table_start = blob.len() - 32 + 24; // offset_table_offset lives here
+        let table_off = read_be(&blob[table_start..table_start + 8]);
+        // Point the first object offset at the trailer region.
+        blob[table_off] = (blob.len() - 4) as u8;
+        assert_eq!(int_array(&blob), None);
+    }
+
+    // Big-endian read helper for the corruption test above.
+    fn read_be(bytes: &[u8]) -> usize {
+        bytes.iter().fold(0usize, |acc, &b| (acc << 8) | b as usize)
     }
 }

--- a/src/kakao/reader.rs
+++ b/src/kakao/reader.rs
@@ -146,33 +146,24 @@ fn load_rooms(conn: &Connection) -> Result<HashMap<i64, RoomMeta>> {
 /// the highest `revision` when a room was renamed more than once. An older
 /// schema without the table — or any read error — simply leaves titles unset.
 fn enrich_titles(conn: &Connection, rooms: &mut HashMap<i64, RoomMeta>) {
+    // Order ascending and overwrite as we go, so the last row seen per room is the
+    // highest revision — with `content` breaking exact-revision ties — making the
+    // chosen title deterministic regardless of SQLite's row order.
     let Ok(mut stmt) = conn.prepare(
-        "SELECT chatId, content, revision FROM NTChatMeta
-         WHERE type = 3 AND content IS NOT NULL AND content <> ''",
+        "SELECT chatId, content FROM NTChatMeta
+         WHERE type = 3 AND content IS NOT NULL AND content <> ''
+         ORDER BY revision ASC, content ASC",
     ) else {
         return;
     };
     let Ok(rows) = stmt.query_map([], |row| {
-        let chat_id: i64 = row.get(0)?;
-        let content: String = row.get(1)?;
-        let revision: i64 = row.get(2).unwrap_or(0);
-        Ok((chat_id, content, revision))
+        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
     }) else {
         return;
     };
-    // Keep the latest title (highest revision) per room.
-    let mut best: HashMap<i64, (i64, String)> = HashMap::new();
-    for (chat_id, content, revision) in rows.flatten() {
-        match best.get(&chat_id) {
-            Some((seen, _)) if *seen >= revision => {}
-            _ => {
-                best.insert(chat_id, (revision, content));
-            }
-        }
-    }
-    for (chat_id, (_, title)) in best {
+    for (chat_id, content) in rows.flatten() {
         if let Some(meta) = rooms.get_mut(&chat_id) {
-            meta.title = Some(title);
+            meta.title = Some(content);
         }
     }
 }
@@ -210,8 +201,12 @@ fn enrich_display_members(conn: &Connection, rooms: &mut HashMap<i64, RoomMeta>)
 fn resolve_chat_name(
     meta: Option<&RoomMeta>,
     chat_id: i64,
+    self_user_id: i64,
     users: &HashMap<i64, String>,
 ) -> String {
+    // Cap the reconstructed group name so a long member list stays readable and
+    // a corrupt one cannot bloat the name cloned onto every message.
+    const MAX_DISPLAY_MEMBERS: usize = 8;
     if let Some(meta) = meta {
         if let Some(name) = &meta.name {
             return name.clone();
@@ -219,7 +214,9 @@ fn resolve_chat_name(
         if let Some(title) = &meta.title {
             return title.clone();
         }
-        if meta.direct_member_id != 0 {
+        // Direct chat: the peer's nickname. Never the account owner itself
+        // (a self-chat / anomalous room must fall through, not take our name).
+        if meta.direct_member_id != 0 && meta.direct_member_id != self_user_id {
             if let Some(name) = users.get(&meta.direct_member_id) {
                 return name.clone();
             }
@@ -227,7 +224,9 @@ fn resolve_chat_name(
         let joined: Vec<&str> = meta
             .display_member_ids
             .iter()
+            .filter(|id| **id != self_user_id)
             .filter_map(|id| users.get(id).map(String::as_str))
+            .take(MAX_DISPLAY_MEMBERS)
             .collect();
         if !joined.is_empty() {
             return joined.join(", ");
@@ -342,7 +341,12 @@ fn read_one(
     // then reuse per message rather than recomputing a join per row.
     let chat_names: HashMap<i64, String> = rooms
         .iter()
-        .map(|(chat_id, meta)| (*chat_id, resolve_chat_name(Some(meta), *chat_id, users)))
+        .map(|(chat_id, meta)| {
+            (
+                *chat_id,
+                resolve_chat_name(Some(meta), *chat_id, user_id, users),
+            )
+        })
         .collect();
 
     let mut stmt = conn

--- a/tests/reader_synthetic_db.rs
+++ b/tests/reader_synthetic_db.rs
@@ -419,3 +419,88 @@ fn reconstructs_names_for_unnamed_rooms() {
         .expect("group message");
     assert_eq!(group_msg.chat_name, "Alice, BobNick");
 }
+
+/// An older KakaoTalk schema without an `NTChatMeta` table and without the
+/// `NTChatRoom.displayMemberIds` column must still read: the best-effort title
+/// and member enrichment skip cleanly, and an unnamed room keeps `chat-<id>`.
+#[test]
+fn reads_older_schema_without_title_or_member_columns() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = temp.path().join("home");
+    let data_dir = temp.path().join("data");
+    std::fs::create_dir_all(&data_dir).expect("data dir");
+
+    let container = auth::container_dir(&home);
+    std::fs::create_dir_all(&container).expect("container dir");
+    let db_name = derive::database_name(TEST_USER_ID, TEST_UUID);
+    let db_path = container.join(&db_name);
+    let key = derive::secure_key(TEST_USER_ID, TEST_UUID);
+
+    let conn = Connection::open(&db_path).expect("open db");
+    conn.execute_batch(&format!(
+        "PRAGMA key = '{key}'; PRAGMA cipher_compatibility = 3;"
+    ))
+    .expect("cipher key");
+    // No displayMemberIds column, and no NTChatMeta table at all.
+    conn.execute_batch(
+        "CREATE TABLE NTChatRoom (
+            chatId INTEGER NOT NULL DEFAULT 0,
+            linkId INTEGER NOT NULL DEFAULT 0,
+            type INTEGER NOT NULL DEFAULT 0,
+            chatName TEXT,
+            activeMembersCount INTEGER NOT NULL DEFAULT 0,
+            directChatMemberUserId INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (chatId, linkId)
+        );
+        CREATE TABLE NTUser (
+            userId INTEGER NOT NULL DEFAULT 0,
+            linkId INTEGER NOT NULL DEFAULT 0,
+            friendNickName TEXT,
+            nickName TEXT,
+            displayName TEXT,
+            PRIMARY KEY (userId, linkId)
+        );
+        CREATE TABLE NTChatMessage (
+            chatId INTEGER NOT NULL DEFAULT 0,
+            logId INTEGER NOT NULL DEFAULT 0,
+            msgId INTEGER NOT NULL DEFAULT 0,
+            authorId INTEGER NOT NULL DEFAULT 0,
+            type INTEGER NOT NULL DEFAULT -1,
+            supplement TEXT,
+            message TEXT,
+            sentAt INTEGER DEFAULT 0,
+            PRIMARY KEY (chatId, logId, msgId)
+        );",
+    )
+    .expect("create old schema");
+    conn.execute(
+        "INSERT INTO NTChatRoom(chatId, linkId, type, chatName, activeMembersCount, directChatMemberUserId)
+         VALUES (700, 0, 1, '', 3, 0)",
+        [],
+    )
+    .expect("room");
+    conn.execute(
+        "INSERT INTO NTChatMessage(chatId, logId, msgId, authorId, type, supplement, message, sentAt)
+         VALUES (700, 70, 1, 800, 1, NULL, 'old schema hi', 1700000000)",
+        [],
+    )
+    .expect("message");
+    drop(conn);
+
+    let options = AuthOptions {
+        home,
+        data_dir,
+        user_id_override: Some(TEST_USER_ID),
+        uuid_override: Some(TEST_UUID.to_string()),
+        max_user_id: 0,
+    };
+    let output = katok::kakao::read_kakao_with_options(&options).expect("read kakao");
+
+    assert_eq!(output.messages.len(), 1);
+    let chat = output
+        .chats
+        .iter()
+        .find(|chat| chat.chat_id == "700")
+        .expect("chat 700");
+    assert_eq!(chat.chat_name, "chat-700");
+}


### PR DESCRIPTION
#2 를 빠르게 머지해 주셔서 감사합니다. 머지 직후에 #2 브랜치를 cross-engine(Codex)으로 한 번 더 적대적 셀프리뷰했는데, 견고성 관련해서 손볼 지점이 몇 개 나와서 후속으로 올립니다. 전부 기능 변화 없이 방어 코드/경계 검증만 강화합니다.

## 고친 것

- **bplist 경계 검증 강화**: 오프셋 테이블이 header 와 trailer 사이에 있는지, 각 object offset 이 object 영역 안을 가리키는지 검증합니다. malformed `displayMemberIds` blob 을 구조 바이트를 멤버 id 로 오해석하지 않고 `None` 으로 degrade 합니다. 원소 개수 상한(`MAX_ELEMENTS`)도 둡니다.
- **8바이트 정수 오버플로**: bplist 정수를 `i64::try_from` 으로 읽어, `i64::MAX` 초과 값이 음수로 wrap 되지 않고 거부되게 합니다.
- **`--limit` 오버플로**: `--limit` 을 `1..=100000` 으로 바운드합니다. 이전에는 아주 큰 값이 `as i64` 캐스팅에서 음수가 되어 SQLite `LIMIT` 을 사실상 무제한으로 만들 수 있었습니다.
- **개인방 self 명명 방지**: `directChatMemberUserId` 가 계정 본인이면(self-chat 등) 본인 이름으로 방을 짓지 않고 fallback 합니다.
- **그룹 이름 상한**: 복원한 그룹 이름을 표시 멤버 앞 몇 명으로 제한해, 긴/손상된 멤버 리스트가 모든 메시지에 복제되는 거대 `chat_name` 이 되지 않게 합니다.
- **제목 선택 결정성**: 동일 `NTChatMeta` revision 에서 제목 선택이 SQLite 행 순서에 흔들리지 않도록 `ORDER BY` 로 결정적으로 고릅니다.

## 테스트

- 구버전 스키마 fixture 추가(`NTChatMeta` 없음 / `displayMemberIds` 컬럼 없음): best-effort 로 skip 하고 `chat-<id>` 로 fallback 하는지 검증.
- bplist malformed 케이스 추가: 원소 개수 상한 초과, object offset 이 trailer 를 가리키는 경우.
- 전체 테스트 통과, `clippy --all-targets -- -D warnings` 및 `fmt` clean.
