### PR TITLE
[katok] 이미지 추출 CLI (media get) 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Added `katok media get` for KakaoTalk image extraction with local Pkv2 `.img`, CDN SHA-1 verified fetch, `.thm` fallback, and stub records.
+- Documented that the CDN presigned GET is the only network tier in image extraction, and that `--no-cdn` disables it for local-only runs.
+- Added synthetic SQLCipher and media-cache tests for full, CDN, thumbnail, stub, no-cdn, SHA-1 mismatch, and album type 27 paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +257,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1201,6 +1240,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,9 +1292,11 @@ dependencies = [
 name = "katok"
 version = "0.1.2"
 dependencies = [
+ "aes",
  "anyhow",
  "assert_cmd",
  "base64 0.22.1",
+ "cbc",
  "chrono",
  "clap",
  "dirs",
@@ -1263,6 +1314,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,10 @@ name = "katok"
 path = "src/main.rs"
 
 [dependencies]
+aes = "0.8"
 anyhow = "1"
 base64 = "0.22"
+cbc = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
@@ -39,6 +41,7 @@ sha2 = "0.10"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 toml = "0.8"
+ureq = "3.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ katok chunk parent <chunk-id> --json
 - `chunk context`는 같은 채팅방의 바로 앞뒤 chunk를 보여줍니다.
 - `chunk parent`는 semantic search가 사용한 더 큰 parent window를 보여줍니다.
 
+카카오톡 이미지 메시지의 로컬 캐시를 추출하려면 media 명령을 사용합니다.
+
+```bash
+katok media get --chat <chat-id> --json
+katok media get --chat <chat-id> --log <log-id> --out ./katok-media --no-cdn --json
+```
+
+`media get`은 type 2 단일 사진과 type 27 앨범 프레임을 읽고, 각 프레임을 로컬 full `.img`, CDN presigned GET, 로컬 thumbnail `.thm`, stub 순서로 해석합니다. 이미지 추출 자체가 사용자가 `media get`을 실행해 opt in하는 기능이며, 이 명령에서 네트워크를 사용할 수 있는 유일한 동작은 attachment metadata의 CDN presigned GET입니다. CDN 응답은 `cs` SHA-1과 일치한 bytes만 저장하며, `--no-cdn`을 주면 CDN tier를 끄고 로컬 `.img`/`.thm`/stub만 사용합니다. 기본 출력 위치는 katok data directory 아래 `media/<chat-id>/`입니다.
+
+`--json` 출력 스키마의 주요 필드는 다음과 같습니다.
+
+- `chat_id`, `log_id`, `limit`, `output_dir`, `cdn_enabled`
+- `frame_count`: 읽은 이미지 frame 수
+- `records[]`: `logId`, `idx`, `w`, `h`, `cs`, `tier`, `tier_reason`, `path`, `sha1`, `sender`, `ts`
+- `errors[]`: tier 실패 관측값, `logId`, `idx`, `stage`, `path`, `error`
+- `tier_counts`: `full`, `cdn`, `thumb`, `stub` 별 개수
+
 ## 검색 방식
 
 `katok search keyword`는 빠르고 결정적인 부분 문자열 검색입니다. 정확한 단어, 이름, 계좌번호, 고유명사처럼 그대로 기억나는 값을 찾을 때 씁니다.
@@ -201,6 +218,7 @@ katok search semantic "회의 보고서" --json
 katok chunk get <chunk-id> --json
 katok chunk context <chunk-id> --json
 katok chunk parent <chunk-id> --json
+katok media get --chat <chat-id> --no-cdn --json
 katok wipe-index --yes --json
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,10 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: SourceCommand,
     },
+    Media {
+        #[command(subcommand)]
+        command: MediaCommand,
+    },
     Permissions {
         #[command(subcommand)]
         command: PermissionsCommand,
@@ -122,6 +126,29 @@ pub(crate) enum SourceCommand {
         #[arg(long)]
         source: Option<String>,
         path: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum MediaCommand {
+    Get {
+        /// KakaoTalk chatId to read image messages from.
+        #[arg(long)]
+        chat: i64,
+        /// Optional KakaoTalk logId to extract one image message.
+        #[arg(long)]
+        log: Option<i64>,
+        /// Output directory for decrypted/fetched image files.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Disable CDN downloads and use only local cache/thumbnail/stub tiers.
+        #[arg(long)]
+        no_cdn: bool,
+        /// Maximum number of image messages to read from the room.
+        #[arg(long, default_value_t = 5000, value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=100_000))]
+        limit: usize,
         #[arg(long)]
         json: bool,
     },

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 mod chunk_commands;
 mod freshness;
 mod index_commands;
+mod media_commands;
 mod permissions;
 mod source_adapter;
 
@@ -53,6 +54,7 @@ pub(crate) fn run(
         Commands::Search { command } => run_search(command, &config, &archive_path, &semantic_dir),
         Commands::Chunk { command } => chunk_commands::run(command, &archive_path),
         Commands::Source { command } => run_source(command, &config, &data_dir),
+        Commands::Media { command } => media_commands::run(command, &data_dir),
         Commands::Permissions { command } => run_permissions(command),
         Commands::Chunks { chat, json } => run_chunks(&chat, json, &archive_path),
         Commands::WipeIndex { yes, json } => run_wipe_index(yes, json, &semantic_dir),

--- a/src/commands/media_commands.rs
+++ b/src/commands/media_commands.rs
@@ -1,0 +1,73 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::cli::MediaCommand;
+use crate::support::print_payload;
+use katok::kakao::{
+    media_paths::MediaDirs, media_resolver::MediaResolveOptions, read_media_frames_with_options,
+    AuthOptions, MediaQuery,
+};
+
+pub(crate) fn run(command: MediaCommand, data_dir: &Path) -> Result<()> {
+    match command {
+        MediaCommand::Get {
+            chat,
+            log,
+            out,
+            no_cdn,
+            limit,
+            json,
+        } => run_get(chat, log, out, no_cdn, limit, json, data_dir),
+    }
+}
+
+fn run_get(
+    chat_id: i64,
+    log_id: Option<i64>,
+    out: Option<PathBuf>,
+    no_cdn: bool,
+    limit: usize,
+    json: bool,
+    data_dir: &Path,
+) -> Result<()> {
+    let home = katok::kakao::default_home().context("resolve home directory")?;
+    let auth_options = AuthOptions::new(home.clone(), data_dir.to_path_buf());
+    let query = MediaQuery {
+        chat_id,
+        log_id,
+        limit,
+    };
+    let frames = read_media_frames_with_options(&auth_options, &query)
+        .context("read KakaoTalk media rows")?;
+    let output_dir = out.unwrap_or_else(|| data_dir.join("media").join(chat_id.to_string()));
+    let report = if frames.is_empty() {
+        katok::kakao::media_resolver::MediaReport {
+            records: Vec::new(),
+            errors: Vec::new(),
+            tier_counts: std::collections::BTreeMap::new(),
+        }
+    } else {
+        katok::paths::ensure_private_dir(&output_dir).context("create private media output dir")?;
+        let media_dirs = MediaDirs::discover(&home).context("scan KakaoTalk media cache dirs")?;
+        let options = MediaResolveOptions {
+            output_dir: output_dir.clone(),
+            cdn_enabled: !no_cdn,
+            ..MediaResolveOptions::new(output_dir.clone())
+        };
+        katok::kakao::media_resolver::resolve_media_frames(chat_id, &frames, &media_dirs, &options)
+            .context("resolve media tiers")?
+    };
+    let payload = serde_json::json!({
+        "chat_id": chat_id,
+        "log_id": log_id,
+        "limit": limit,
+        "output_dir": output_dir,
+        "cdn_enabled": !no_cdn,
+        "frame_count": frames.len(),
+        "records": report.records,
+        "errors": report.errors,
+        "tier_counts": report.tier_counts,
+    });
+    print_payload(json, &payload)
+}

--- a/src/kakao/media_crypto.rs
+++ b/src/kakao/media_crypto.rs
@@ -1,0 +1,142 @@
+//! Pkv2 media decryption for KakaoTalk macOS image cache files.
+//!
+//! A Pkv2 file is `b"Pkv2" || iv[16] || AES-256-CBC-PKCS7(ciphertext)`.
+//! The decrypted plaintext has a 256-byte wrapper before the image bytes.
+
+use aes::Aes256;
+use cbc::cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit};
+use sha2::{Digest, Sha256};
+
+use crate::{Error, Result};
+
+const PKV2_MAGIC: &[u8; 4] = b"Pkv2";
+const IV_LEN: usize = 16;
+const PLAINTEXT_HEADER_LEN: usize = 256;
+
+type Aes256CbcDecryptor = cbc::Decryptor<Aes256>;
+
+/// The key string fed to KakaoTalk's `mactalkAESDecrypt:` for image media.
+pub fn media_key_string(log_id: i64) -> String {
+    format!("#{log_id}%").chars().rev().collect()
+}
+
+/// Decrypt bytes after the 4-byte Pkv2 magic, returning wrapper + image bytes.
+pub fn mactalk_aes_decrypt(data: &[u8], key_string: &str) -> Result<Vec<u8>> {
+    if data.len() <= IV_LEN {
+        return Err(Error::Kakao(
+            "invalid Pkv2 payload: missing ciphertext".to_string(),
+        ));
+    }
+    let (iv, ciphertext) = data.split_at(IV_LEN);
+    if ciphertext.len() % IV_LEN != 0 {
+        return Err(Error::Kakao(
+            "invalid Pkv2 payload: ciphertext is not block-aligned".to_string(),
+        ));
+    }
+
+    let aes_key = Sha256::digest(key_string.as_bytes());
+    let mut buf = ciphertext.to_vec();
+    let plaintext = Aes256CbcDecryptor::new_from_slices(&aes_key, iv)
+        .map_err(|_| Error::Kakao("invalid Pkv2 AES key or IV".to_string()))?
+        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .map_err(|_| Error::Kakao("invalid Pkv2 PKCS7 padding".to_string()))?;
+    Ok(plaintext.to_vec())
+}
+
+/// Decrypt a raw `.img`/`.thm` Pkv2 file into image bytes.
+pub fn decrypt_pkv2_image(file_bytes: &[u8], log_id: i64) -> Result<Vec<u8>> {
+    let Some(payload) = file_bytes.strip_prefix(PKV2_MAGIC) else {
+        return Err(Error::Kakao("not a Pkv2 file".to_string()));
+    };
+    let plaintext = mactalk_aes_decrypt(payload, &media_key_string(log_id))?;
+    if plaintext.len() < PLAINTEXT_HEADER_LEN {
+        return Err(Error::Kakao(
+            "invalid Pkv2 plaintext: missing media wrapper".to_string(),
+        ));
+    }
+    Ok(plaintext[PLAINTEXT_HEADER_LEN..].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha1::{Digest as Sha1Digest, Sha1};
+
+    const VECTOR_LOG_ID: i64 = 1_234_567_890_123;
+    const VECTOR_IMAGE_HEX: &str = "ffd8ffe04b41544f4b2d504b56322d54455354ffd9";
+    const VECTOR_IMAGE_SHA1: &str = "91ed9414d7eb34fe648db42be27a0b7847dc8c8e";
+    // Generated from the Python reference algorithm with:
+    // log_id=1234567890123, iv=00..0f, plaintext=(b"0123456789abcdef"*16)+image.
+    const PYTHON_REFERENCE_PKV2_HEX: &str = concat!(
+        "506b7632000102030405060708090a0b0c0d0e0f554b63056928134b57397f6a2e06f1f04",
+        "faf2ce5a3905914af3afabf90b8605bc39e6f7ffe132a0bd65963bc6fdbc111d283724581",
+        "b869f60e1c85fedaf14265380a50c41ab3efa9a46bade5e1bce7dc175f8fc5d06a29cc",
+        "14bb8afbe382eb5bba3e676fd35b0c002fdf5621adedc2d344db8c97873ae4c62769b",
+        "38524501062322c5258f86688e325f549a11696b3e68ed354979c4df585732c1d42b",
+        "49afe3ac97b46997e39c43e9818cdd9870b7032d8da56cfe0663201a1daa321ad7",
+        "a1ee6bbdb584d7b76ca562e05d26eeb3dd7b777c01c18e091bb177fef85bb1013c",
+        "6b632c75112780f8f1b423dc5587e17ca1aacc3c8a585373fe2142cd299303fd1",
+        "ec64340e58e9dabd4c6f1b2d5298eab53a925efb785f0eac9961d736046ba914fd"
+    );
+
+    fn bytes_from_hex(input: &str) -> Vec<u8> {
+        assert_eq!(input.len() % 2, 0);
+        input
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let text = std::str::from_utf8(pair).expect("hex is utf8");
+                u8::from_str_radix(text, 16).expect("valid hex")
+            })
+            .collect()
+    }
+
+    fn sha1_hex(bytes: &[u8]) -> String {
+        let digest = Sha1::digest(bytes);
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            out.push(HEX[(byte >> 4) as usize] as char);
+            out.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        out
+    }
+
+    #[test]
+    fn media_key_string_matches_reference_format() {
+        assert_eq!(media_key_string(VECTOR_LOG_ID), "%3210987654321#");
+    }
+
+    #[test]
+    fn decrypts_python_reference_pkv2_vector() {
+        let file_bytes = bytes_from_hex(PYTHON_REFERENCE_PKV2_HEX);
+        let image = decrypt_pkv2_image(&file_bytes, VECTOR_LOG_ID).expect("decrypt vector");
+
+        assert_eq!(image, bytes_from_hex(VECTOR_IMAGE_HEX));
+        assert_eq!(sha1_hex(&image), VECTOR_IMAGE_SHA1);
+        assert_eq!(&image[..3], b"\xff\xd8\xff");
+    }
+
+    #[test]
+    fn same_log_id_key_path_is_media_kind_agnostic() {
+        let file_bytes = bytes_from_hex(PYTHON_REFERENCE_PKV2_HEX);
+
+        let img = decrypt_pkv2_image(&file_bytes, VECTOR_LOG_ID).expect(".img decrypt");
+        let thm = decrypt_pkv2_image(&file_bytes, VECTOR_LOG_ID).expect(".thm decrypt");
+
+        assert_eq!(img, thm);
+    }
+
+    #[test]
+    fn rejects_non_pkv2_files() {
+        let err = decrypt_pkv2_image(b"nope", VECTOR_LOG_ID).expect_err("invalid magic");
+        assert!(err.to_string().contains("not a Pkv2 file"));
+    }
+
+    #[test]
+    fn rejects_unaligned_ciphertext() {
+        let err = mactalk_aes_decrypt(&[0; IV_LEN + 1], &media_key_string(VECTOR_LOG_ID))
+            .expect_err("unaligned ciphertext");
+        assert!(err.to_string().contains("block-aligned"));
+    }
+}

--- a/src/kakao/media_paths.rs
+++ b/src/kakao/media_paths.rs
@@ -1,0 +1,175 @@
+//! KakaoTalk media-cache path helpers.
+//!
+//! Media files live below 40-hex account directories in the KakaoTalk macOS
+//! container. Each chat room is a SHA-1 of the reversed chat id, and each media
+//! filename stem is a SHA-1 of the reversed KakaoTalk media key string.
+
+use std::path::{Path, PathBuf};
+
+use sha1::{Digest, Sha1};
+
+use super::auth;
+use crate::{Error, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaDirs {
+    roots: Vec<PathBuf>,
+}
+
+impl MediaDirs {
+    /// Scan the KakaoTalk container once for direct 40-hex media account dirs.
+    ///
+    /// This is intentionally bounded to one directory level. A missing or
+    /// unreadable container is an error; an empty media-dir set is a valid
+    /// cache state and simply makes lookups miss.
+    pub fn discover(home: &Path) -> Result<Self> {
+        Self::discover_in_container(&auth::container_dir(home))
+    }
+
+    pub fn discover_in_container(container: &Path) -> Result<Self> {
+        if !container.is_dir() {
+            return Err(Error::Kakao(format!(
+                "kakao media container not found: {}",
+                container.display()
+            )));
+        }
+        let entries = std::fs::read_dir(container).map_err(|err| {
+            Error::Kakao(format!(
+                "cannot scan kakao media container {}: {err}",
+                container.display()
+            ))
+        })?;
+        let mut roots = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|err| {
+                Error::Kakao(format!(
+                    "cannot scan kakao media container {}: {err}",
+                    container.display()
+                ))
+            })?;
+            let path = entry.path();
+            let is_media_account = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(is_media_account_dir_name);
+            if is_media_account && path.is_dir() {
+                roots.push(path);
+            }
+        }
+        roots.sort();
+        Ok(Self { roots })
+    }
+
+    pub fn from_roots_for_test(mut roots: Vec<PathBuf>) -> Self {
+        roots.sort();
+        Self { roots }
+    }
+
+    pub fn roots(&self) -> &[PathBuf] {
+        &self.roots
+    }
+
+    /// Search every account dir for `<sha1_rev(chat_id)>/<stem><ext>`.
+    pub fn find_media_file(&self, chat_id: i64, name_stem: &str, ext: &str) -> Option<PathBuf> {
+        let chat_sha = chat_media_dir_name(chat_id);
+        let filename = format!("{name_stem}{ext}");
+        self.roots
+            .iter()
+            .map(|root| root.join(&chat_sha).join(&filename))
+            .find(|candidate| candidate.is_file())
+    }
+}
+
+pub fn sha1_rev(input: &str) -> String {
+    sha1_hex(input.chars().rev().collect::<String>().as_bytes())
+}
+
+pub fn chat_media_dir_name(chat_id: i64) -> String {
+    sha1_rev(&chat_id.to_string())
+}
+
+pub fn photo_full_stem(log_id: i64) -> String {
+    sha1_rev(&format!("p{log_id}"))
+}
+
+pub fn photo_thumb_stem(log_id: i64) -> String {
+    sha1_rev(&format!("t{log_id}"))
+}
+
+pub fn album_full_stem(log_id: i64, idx: usize) -> String {
+    sha1_rev(&format!("p{idx}_{log_id}"))
+}
+
+pub fn album_thumb_stem(log_id: i64, idx: usize) -> String {
+    sha1_rev(&format!("t{idx}_{log_id}"))
+}
+
+fn is_media_account_dir_name(name: &str) -> bool {
+    name.len() == 40
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn sha1_hex(bytes: &[u8]) -> String {
+    let digest = Sha1::digest(bytes);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha1_rev_matches_python_reference() {
+        assert_eq!(
+            sha1_rev("p1234567890123"),
+            "6a57dbd91a25d5f1e503c316e13487b6abd8de5c"
+        );
+        assert_eq!(
+            chat_media_dir_name(1234567890123),
+            "f3040a56bce932b9fe31cf4e68a2eae23c33165b"
+        );
+    }
+
+    #[test]
+    fn discovers_only_lowercase_40_hex_account_dirs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let valid = tmp.path().join("0123456789abcdef0123456789abcdef01234567");
+        let uppercase = tmp.path().join("abcdefabcdefabcdefabcdefabcdefabcdefABCD");
+        let too_long = tmp.path().join("0123456789abcdef0123456789abcdef012345678");
+        std::fs::create_dir(&valid).expect("valid dir");
+        std::fs::create_dir(&uppercase).expect("uppercase dir");
+        std::fs::create_dir(&too_long).expect("too-long dir");
+        std::fs::write(
+            tmp.path().join("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            b"file",
+        )
+        .expect("media-looking file");
+
+        let dirs = MediaDirs::discover_in_container(tmp.path()).expect("discover");
+
+        assert_eq!(dirs.roots(), &[valid]);
+    }
+
+    #[test]
+    fn finds_media_by_account_chat_and_stem() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("0123456789abcdef0123456789abcdef01234567");
+        let chat_dir = root.join(chat_media_dir_name(42));
+        std::fs::create_dir_all(&chat_dir).expect("chat dir");
+        let stem = photo_full_stem(77);
+        let expected = chat_dir.join(format!("{stem}.img"));
+        std::fs::write(&expected, b"media").expect("media file");
+        let dirs = MediaDirs::from_roots_for_test(vec![root]);
+
+        assert_eq!(dirs.find_media_file(42, &stem, ".img"), Some(expected));
+        assert_eq!(dirs.find_media_file(43, &stem, ".img"), None);
+    }
+}

--- a/src/kakao/media_reader.rs
+++ b/src/kakao/media_reader.rs
@@ -1,0 +1,277 @@
+//! Read KakaoTalk image message rows and normalize them into media resolver
+//! frame inputs.
+//!
+//! This reader is intentionally separate from the archive/search reader: image
+//! rows can have empty message text, and the extraction path needs attachment
+//! metadata rather than conversation bodies.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use rusqlite::params;
+
+use super::media_paths::{album_full_stem, album_thumb_stem, photo_full_stem, photo_thumb_stem};
+use super::media_resolver::MediaFrameInput;
+use super::{auth, derive, reader, AuthOptions};
+use crate::Result;
+
+const ALBUM_MESSAGE_TYPE: i64 = 27;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaQuery {
+    pub chat_id: i64,
+    pub log_id: Option<i64>,
+    pub limit: usize,
+}
+
+pub fn read_media_frames_with_options(
+    options: &AuthOptions,
+    query: &MediaQuery,
+) -> Result<Vec<MediaFrameInput>> {
+    let resolved = auth::resolve_auth(options)?;
+    read_media_frames_from_databases(
+        &resolved.database_files,
+        resolved.user_id,
+        &resolved.uuid,
+        query,
+    )
+}
+
+pub fn read_media_frames_from_databases(
+    database_files: &[PathBuf],
+    user_id: i64,
+    uuid: &str,
+    query: &MediaQuery,
+) -> Result<Vec<MediaFrameInput>> {
+    let key = derive::secure_key(user_id, uuid);
+    let mut frames = Vec::new();
+    let mut seen = HashSet::new();
+
+    for path in database_files {
+        let Ok(conn) = reader::open_database(path, &key) else {
+            eprintln!("katok: skipping unreadable KakaoTalk db");
+            continue;
+        };
+        let rows = read_media_rows(&conn, query)?;
+        for row in rows {
+            for frame in frame_inputs(row) {
+                if seen.insert((frame.log_id, frame.idx)) {
+                    frames.push(frame);
+                }
+            }
+        }
+    }
+    Ok(frames)
+}
+
+#[derive(Debug, Clone)]
+struct MediaRow {
+    log_id: i64,
+    author_id: i64,
+    msg_type: i64,
+    sent_at: i64,
+    attachment: Option<String>,
+}
+
+fn read_media_rows(conn: &rusqlite::Connection, query: &MediaQuery) -> Result<Vec<MediaRow>> {
+    if let Some(log_id) = query.log_id {
+        let mut stmt = conn
+            .prepare(
+                "SELECT logId, authorId, type, sentAt, attachment
+                 FROM NTChatMessage
+                 WHERE chatId = ?1 AND logId = ?2 AND type IN (2, 27)
+                 ORDER BY sentAt ASC, logId ASC
+                 LIMIT ?3",
+            )
+            .map_err(crate::Error::Sql)?;
+        let rows = stmt
+            .query_map(
+                params![query.chat_id, log_id, query.limit as i64],
+                map_media_row,
+            )
+            .map_err(crate::Error::Sql)?;
+        collect_rows(rows)
+    } else {
+        let mut stmt = conn
+            .prepare(
+                "SELECT logId, authorId, type, sentAt, attachment
+                 FROM NTChatMessage
+                 WHERE chatId = ?1 AND type IN (2, 27)
+                 ORDER BY sentAt ASC, logId ASC
+                 LIMIT ?2",
+            )
+            .map_err(crate::Error::Sql)?;
+        let rows = stmt
+            .query_map(params![query.chat_id, query.limit as i64], map_media_row)
+            .map_err(crate::Error::Sql)?;
+        collect_rows(rows)
+    }
+}
+
+fn collect_rows<I>(rows: I) -> Result<Vec<MediaRow>>
+where
+    I: IntoIterator<Item = rusqlite::Result<MediaRow>>,
+{
+    let mut out = Vec::new();
+    let mut skipped = 0usize;
+    for row in rows {
+        match row {
+            Ok(row) => out.push(row),
+            Err(_) => skipped += 1,
+        }
+    }
+    if skipped > 0 {
+        eprintln!("katok: skipped {skipped} unreadable KakaoTalk media row(s)");
+    }
+    Ok(out)
+}
+
+fn map_media_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<MediaRow> {
+    let sent_at = row.get::<_, f64>(3).unwrap_or(0.0) as i64;
+    Ok(MediaRow {
+        log_id: row.get(0)?,
+        author_id: row.get(1)?,
+        msg_type: row.get(2)?,
+        sent_at,
+        attachment: row.get(4)?,
+    })
+}
+
+fn frame_inputs(row: MediaRow) -> Vec<MediaFrameInput> {
+    let attachment = row
+        .attachment
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    if row.msg_type == ALBUM_MESSAGE_TYPE {
+        if let Some(csl) = attachment.get("csl").and_then(|value| value.as_array()) {
+            return (0..csl.len())
+                .map(|idx| MediaFrameInput {
+                    log_id: row.log_id,
+                    idx,
+                    width: array_i64(&attachment, "wl", idx),
+                    height: array_i64(&attachment, "hl", idx),
+                    checksum_sha1: array_string(&attachment, "csl", idx),
+                    full_stem: album_full_stem(row.log_id, idx),
+                    thumb_stem: album_thumb_stem(row.log_id, idx),
+                    output_stem: format!("{}_{}", row.log_id, idx),
+                    sender: Some(row.author_id.to_string()),
+                    sent_at: Some(row.sent_at),
+                    cdn_url: array_string(&attachment, "imageUrls", idx),
+                })
+                .collect();
+        }
+    }
+
+    vec![MediaFrameInput {
+        log_id: row.log_id,
+        idx: 0,
+        width: object_i64(&attachment, "w"),
+        height: object_i64(&attachment, "h"),
+        checksum_sha1: object_string(&attachment, "cs"),
+        full_stem: photo_full_stem(row.log_id),
+        thumb_stem: photo_thumb_stem(row.log_id),
+        output_stem: row.log_id.to_string(),
+        sender: Some(row.author_id.to_string()),
+        sent_at: Some(row.sent_at),
+        cdn_url: object_string(&attachment, "url"),
+    }]
+}
+
+fn object_i64(root: &serde_json::Value, key: &str) -> Option<i64> {
+    root.get(key).and_then(value_i64)
+}
+
+fn object_string(root: &serde_json::Value, key: &str) -> Option<String> {
+    root.get(key).and_then(value_string)
+}
+
+fn array_i64(root: &serde_json::Value, key: &str, idx: usize) -> Option<i64> {
+    root.get(key)
+        .and_then(|value| value.as_array())
+        .and_then(|array| array.get(idx))
+        .and_then(value_i64)
+}
+
+fn array_string(root: &serde_json::Value, key: &str, idx: usize) -> Option<String> {
+    root.get(key)
+        .and_then(|value| value.as_array())
+        .and_then(|array| array.get(idx))
+        .and_then(value_string)
+}
+
+fn value_i64(value: &serde_json::Value) -> Option<i64> {
+    match value {
+        serde_json::Value::Number(number) => number
+            .as_i64()
+            .or_else(|| number.as_f64().map(|v| v as i64)),
+        serde_json::Value::String(text) => text.trim().parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+fn value_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) if !text.is_empty() => Some(text.clone()),
+        serde_json::Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kakao::media_paths::{album_full_stem, photo_full_stem};
+
+    const PHOTO_MESSAGE_TYPE: i64 = 2;
+
+    #[test]
+    fn normalizes_single_photo_attachment() {
+        let row = MediaRow {
+            log_id: 123,
+            author_id: 456,
+            msg_type: PHOTO_MESSAGE_TYPE,
+            sent_at: 1_700_000_000,
+            attachment: Some(
+                r#"{"w":640,"h":"480","cs":"abc","url":"https://cdn.example/p"}"#.to_string(),
+            ),
+        };
+
+        let frames = frame_inputs(row);
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].idx, 0);
+        assert_eq!(frames[0].width, Some(640));
+        assert_eq!(frames[0].height, Some(480));
+        assert_eq!(frames[0].checksum_sha1.as_deref(), Some("abc"));
+        assert_eq!(frames[0].cdn_url.as_deref(), Some("https://cdn.example/p"));
+        assert_eq!(frames[0].full_stem, photo_full_stem(123));
+        assert_eq!(frames[0].sender.as_deref(), Some("456"));
+    }
+
+    #[test]
+    fn normalizes_album_frames_from_parallel_arrays() {
+        let row = MediaRow {
+            log_id: 900,
+            author_id: 111,
+            msg_type: ALBUM_MESSAGE_TYPE,
+            sent_at: 1_700_000_010,
+            attachment: Some(
+                r#"{"wl":[100,200],"hl":[300],"csl":["a","b"],"imageUrls":["u0","u1"]}"#
+                    .to_string(),
+            ),
+        };
+
+        let frames = frame_inputs(row);
+
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].full_stem, album_full_stem(900, 0));
+        assert_eq!(frames[1].full_stem, album_full_stem(900, 1));
+        assert_eq!(frames[0].height, Some(300));
+        assert_eq!(frames[1].height, None);
+        assert_eq!(frames[1].checksum_sha1.as_deref(), Some("b"));
+        assert_eq!(frames[1].cdn_url.as_deref(), Some("u1"));
+        assert_eq!(frames[1].output_stem, "900_1");
+    }
+}

--- a/src/kakao/media_resolver.rs
+++ b/src/kakao/media_resolver.rs
@@ -1,0 +1,629 @@
+//! Resolve KakaoTalk image media through full cache, CDN, thumbnail, and stub
+//! tiers.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sha1::{Digest, Sha1};
+
+use super::media_crypto::decrypt_pkv2_image;
+use super::media_paths::MediaDirs;
+use crate::{Error, Result};
+
+const DEFAULT_CDN_TIMEOUT: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MediaTier {
+    Full,
+    Cdn,
+    Thumb,
+    Stub,
+}
+
+impl MediaTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Cdn => "cdn",
+            Self::Thumb => "thumb",
+            Self::Stub => "stub",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MediaResolveOptions {
+    pub output_dir: PathBuf,
+    pub cdn_enabled: bool,
+    pub cdn_timeout: Duration,
+    pub now_epoch: i64,
+}
+
+impl MediaResolveOptions {
+    pub fn new(output_dir: PathBuf) -> Self {
+        Self {
+            output_dir,
+            cdn_enabled: true,
+            cdn_timeout: DEFAULT_CDN_TIMEOUT,
+            now_epoch: unix_now_epoch(),
+        }
+    }
+
+    pub fn no_cdn(output_dir: PathBuf) -> Self {
+        Self {
+            cdn_enabled: false,
+            ..Self::new(output_dir)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MediaFrameInput {
+    pub log_id: i64,
+    pub idx: usize,
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+    pub checksum_sha1: Option<String>,
+    pub full_stem: String,
+    pub thumb_stem: String,
+    pub output_stem: String,
+    pub sender: Option<String>,
+    pub sent_at: Option<i64>,
+    pub cdn_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct MediaRecord {
+    #[serde(rename = "logId")]
+    pub log_id: i64,
+    pub idx: usize,
+    #[serde(rename = "w")]
+    pub width: Option<i64>,
+    #[serde(rename = "h")]
+    pub height: Option<i64>,
+    #[serde(rename = "cs")]
+    pub checksum_sha1: Option<String>,
+    pub tier: MediaTier,
+    pub tier_reason: String,
+    pub path: Option<PathBuf>,
+    pub sha1: Option<String>,
+    pub sender: Option<String>,
+    #[serde(rename = "ts")]
+    pub sent_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct MediaResolveError {
+    #[serde(rename = "logId")]
+    pub log_id: i64,
+    pub idx: usize,
+    pub stage: String,
+    pub path: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct MediaReport {
+    pub records: Vec<MediaRecord>,
+    pub errors: Vec<MediaResolveError>,
+    pub tier_counts: BTreeMap<String, usize>,
+}
+
+pub fn resolve_media_frames(
+    chat_id: i64,
+    frames: &[MediaFrameInput],
+    media_dirs: &MediaDirs,
+    options: &MediaResolveOptions,
+) -> Result<MediaReport> {
+    resolve_media_frames_with_fetcher(chat_id, frames, media_dirs, options, cdn_fetch)
+}
+
+pub fn resolve_media_frames_with_fetcher<F>(
+    chat_id: i64,
+    frames: &[MediaFrameInput],
+    media_dirs: &MediaDirs,
+    options: &MediaResolveOptions,
+    mut fetcher: F,
+) -> Result<MediaReport>
+where
+    F: FnMut(&str, Duration) -> Result<Vec<u8>>,
+{
+    let mut report = MediaReport {
+        records: Vec::with_capacity(frames.len()),
+        errors: Vec::new(),
+        tier_counts: BTreeMap::new(),
+    };
+    for frame in frames {
+        let (record, mut errors) = resolve_one(chat_id, frame, media_dirs, options, &mut fetcher)?;
+        *report
+            .tier_counts
+            .entry(record.tier.as_str().to_string())
+            .or_insert(0) += 1;
+        report.records.push(record);
+        report.errors.append(&mut errors);
+    }
+    Ok(report)
+}
+
+pub fn cdn_fetch(url: &str, timeout: Duration) -> Result<Vec<u8>> {
+    let config = ureq::Agent::config_builder()
+        .timeout_global(Some(timeout))
+        .build();
+    let agent: ureq::Agent = config.into();
+    let mut response = agent
+        .get(url)
+        .header("User-Agent", "KakaoTalk")
+        .call()
+        .map_err(|err| Error::Kakao(format!("cdn fetch failed: {err}")))?;
+    response
+        .body_mut()
+        .read_to_vec()
+        .map_err(|err| Error::Kakao(format!("cdn body read failed: {err}")))
+}
+
+pub fn image_ext(body: &[u8]) -> &'static str {
+    if body.starts_with(b"\xff\xd8\xff") {
+        ".jpg"
+    } else if body.starts_with(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]) {
+        ".png"
+    } else if body.starts_with(b"GIF87a") || body.starts_with(b"GIF89a") {
+        ".gif"
+    } else if body.len() >= 12 && body.starts_with(b"RIFF") && &body[8..12] == b"WEBP" {
+        ".webp"
+    } else {
+        ".bin"
+    }
+}
+
+fn resolve_one<F>(
+    chat_id: i64,
+    frame: &MediaFrameInput,
+    media_dirs: &MediaDirs,
+    options: &MediaResolveOptions,
+    fetcher: &mut F,
+) -> Result<(MediaRecord, Vec<MediaResolveError>)>
+where
+    F: FnMut(&str, Duration) -> Result<Vec<u8>>,
+{
+    let mut errors = Vec::new();
+    let mut why = Vec::new();
+
+    let full = media_dirs.find_media_file(chat_id, &frame.full_stem, ".img");
+    if let Some(full_path) = full {
+        match read_and_decrypt(&full_path, frame.log_id) {
+            Ok(body) => {
+                let out =
+                    options
+                        .output_dir
+                        .join(format!("{}{}", frame.output_stem, image_ext(&body)));
+                write_image(&body, &out)?;
+                return Ok((
+                    record(frame, MediaTier::Full, "decrypted", Some(out), &body),
+                    errors,
+                ));
+            }
+            Err(err) => {
+                why.push("full-decrypt-failed".to_string());
+                errors.push(error_record(
+                    frame,
+                    "full",
+                    &full_path.display().to_string(),
+                    err,
+                ));
+            }
+        }
+    } else {
+        why.push("full-not-cached".to_string());
+    }
+
+    if let Some(url) = frame.cdn_url.as_deref().filter(|_| options.cdn_enabled) {
+        match url_expires(url) {
+            Some(expires) if expires < options.now_epoch => why.push("cdn-expired".to_string()),
+            _ => match fetcher(url, options.cdn_timeout).and_then(|body| {
+                verify_cdn_checksum(&body, frame.checksum_sha1.as_deref())?;
+                Ok(body)
+            }) {
+                Ok(body) => {
+                    let out = options.output_dir.join(format!(
+                        "{}{}",
+                        frame.output_stem,
+                        image_ext(&body)
+                    ));
+                    write_image(&body, &out)?;
+                    let reason =
+                        join_reasons(why.iter().map(String::as_str).chain(["cdn-fetched"]));
+                    return Ok((
+                        record(frame, MediaTier::Cdn, &reason, Some(out), &body),
+                        errors,
+                    ));
+                }
+                Err(err) => {
+                    why.push("cdn-failed".to_string());
+                    errors.push(error_record(frame, "cdn", &redact_url(url), err));
+                }
+            },
+        }
+    }
+
+    let thumb = media_dirs.find_media_file(chat_id, &frame.thumb_stem, ".thm");
+    let mut thumb_failed = false;
+    if let Some(thumb_path) = thumb {
+        match read_and_decrypt(&thumb_path, frame.log_id) {
+            Ok(body) => {
+                let out = options.output_dir.join(format!(
+                    "{}_thumb{}",
+                    frame.output_stem,
+                    image_ext(&body)
+                ));
+                write_image(&body, &out)?;
+                let reason = join_reasons(why.iter().map(String::as_str));
+                return Ok((
+                    record(frame, MediaTier::Thumb, &reason, Some(out), &body),
+                    errors,
+                ));
+            }
+            Err(err) => {
+                thumb_failed = true;
+                errors.push(error_record(
+                    frame,
+                    "thumb",
+                    &thumb_path.display().to_string(),
+                    err,
+                ));
+            }
+        }
+    }
+
+    let stub_head = if thumb_failed || why.iter().any(|item| item == "full-decrypt-failed") {
+        "decrypt-failed"
+    } else {
+        "not-cached"
+    };
+    let mut detail: Vec<&str> = why
+        .iter()
+        .map(String::as_str)
+        .filter(|item| *item != "full-not-cached" && *item != "full-decrypt-failed")
+        .collect();
+    if thumb_failed {
+        detail.push("thumb-decrypt-failed");
+    }
+    let reason = join_reasons(std::iter::once(stub_head).chain(detail));
+    Ok((record(frame, MediaTier::Stub, &reason, None, &[]), errors))
+}
+
+fn record(
+    frame: &MediaFrameInput,
+    tier: MediaTier,
+    reason: &str,
+    path: Option<PathBuf>,
+    body: &[u8],
+) -> MediaRecord {
+    MediaRecord {
+        log_id: frame.log_id,
+        idx: frame.idx,
+        width: frame.width,
+        height: frame.height,
+        checksum_sha1: frame.checksum_sha1.clone(),
+        tier,
+        tier_reason: reason.to_string(),
+        path,
+        sha1: if body.is_empty() {
+            None
+        } else {
+            Some(sha1_hex(body))
+        },
+        sender: frame.sender.clone(),
+        sent_at: frame.sent_at,
+    }
+}
+
+fn error_record(frame: &MediaFrameInput, stage: &str, path: &str, err: Error) -> MediaResolveError {
+    MediaResolveError {
+        log_id: frame.log_id,
+        idx: frame.idx,
+        stage: stage.to_string(),
+        path: path.to_string(),
+        error: err.to_string(),
+    }
+}
+
+fn read_and_decrypt(path: &Path, log_id: i64) -> Result<Vec<u8>> {
+    let bytes = std::fs::read(path)?;
+    decrypt_pkv2_image(&bytes, log_id)
+}
+
+fn verify_cdn_checksum(body: &[u8], expected: Option<&str>) -> Result<()> {
+    let Some(expected) = expected.filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    let actual = sha1_hex(body);
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(Error::Kakao(format!(
+            "cdn body sha1 != cs (expected {}, actual {})",
+            expected.to_ascii_lowercase(),
+            actual
+        )))
+    }
+}
+
+fn write_image(body: &[u8], out: &Path) -> Result<()> {
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = tmp_path(out);
+    std::fs::write(&tmp, body)?;
+    std::fs::rename(&tmp, out).map_err(|err| {
+        let _ = std::fs::remove_file(&tmp);
+        Error::Io(err)
+    })
+}
+
+fn tmp_path(out: &Path) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let filename = out
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("media");
+    out.with_file_name(format!(".{filename}.tmp-{}-{nonce}", std::process::id()))
+}
+
+fn url_expires(url: &str) -> Option<i64> {
+    url.split(['?', '&'])
+        .find_map(|part| part.strip_prefix("expires=")?.parse::<i64>().ok())
+}
+
+fn redact_url(url: &str) -> String {
+    url.split('?').next().unwrap_or(url).to_string()
+}
+
+fn join_reasons<'a>(items: impl IntoIterator<Item = &'a str>) -> String {
+    items.into_iter().collect::<Vec<_>>().join("+")
+}
+
+fn sha1_hex(bytes: &[u8]) -> String {
+    let digest = Sha1::digest(bytes);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn unix_now_epoch() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kakao::media_paths::{chat_media_dir_name, photo_full_stem, photo_thumb_stem};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    const LOG_ID: i64 = 1_234_567_890_123;
+    const CHAT_ID: i64 = 467_153_603_041_939;
+    const VECTOR_IMAGE_HEX: &str = "ffd8ffe04b41544f4b2d504b56322d54455354ffd9";
+    const VECTOR_IMAGE_SHA1: &str = "91ed9414d7eb34fe648db42be27a0b7847dc8c8e";
+    const PYTHON_REFERENCE_PKV2_HEX: &str = concat!(
+        "506b7632000102030405060708090a0b0c0d0e0f554b63056928134b57397f6a2e06f1f04",
+        "faf2ce5a3905914af3afabf90b8605bc39e6f7ffe132a0bd65963bc6fdbc111d283724581",
+        "b869f60e1c85fedaf14265380a50c41ab3efa9a46bade5e1bce7dc175f8fc5d06a29cc",
+        "14bb8afbe382eb5bba3e676fd35b0c002fdf5621adedc2d344db8c97873ae4c62769b",
+        "38524501062322c5258f86688e325f549a11696b3e68ed354979c4df585732c1d42b",
+        "49afe3ac97b46997e39c43e9818cdd9870b7032d8da56cfe0663201a1daa321ad7",
+        "a1ee6bbdb584d7b76ca562e05d26eeb3dd7b777c01c18e091bb177fef85bb1013c",
+        "6b632c75112780f8f1b423dc5587e17ca1aacc3c8a585373fe2142cd299303fd1",
+        "ec64340e58e9dabd4c6f1b2d5298eab53a925efb785f0eac9961d736046ba914fd"
+    );
+
+    fn bytes_from_hex(input: &str) -> Vec<u8> {
+        assert_eq!(input.len() % 2, 0);
+        input
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let text = std::str::from_utf8(pair).expect("hex is utf8");
+                u8::from_str_radix(text, 16).expect("valid hex")
+            })
+            .collect()
+    }
+
+    fn fixture() -> (tempfile::TempDir, MediaDirs, MediaResolveOptions) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let account = tmp.path().join("0123456789abcdef0123456789abcdef01234567");
+        let output_dir = tmp.path().join("out");
+        std::fs::create_dir_all(&account).expect("account dir");
+        let dirs = MediaDirs::from_roots_for_test(vec![account]);
+        let mut options = MediaResolveOptions::new(output_dir);
+        options.now_epoch = 1_700_000_000;
+        (tmp, dirs, options)
+    }
+
+    fn frame() -> MediaFrameInput {
+        MediaFrameInput {
+            log_id: LOG_ID,
+            idx: 0,
+            width: Some(640),
+            height: Some(480),
+            checksum_sha1: Some(VECTOR_IMAGE_SHA1.to_string()),
+            full_stem: photo_full_stem(LOG_ID),
+            thumb_stem: photo_thumb_stem(LOG_ID),
+            output_stem: LOG_ID.to_string(),
+            sender: Some("tester".to_string()),
+            sent_at: Some(1_700_000_001),
+            cdn_url: None,
+        }
+    }
+
+    fn write_cached_media(root: &Path, stem: &str, ext: &str, bytes: &[u8]) -> PathBuf {
+        let path = root
+            .join("0123456789abcdef0123456789abcdef01234567")
+            .join(chat_media_dir_name(CHAT_ID))
+            .join(format!("{stem}{ext}"));
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("chat dir");
+        std::fs::write(&path, bytes).expect("cached media");
+        path
+    }
+
+    #[test]
+    fn resolves_local_full_img_first() {
+        let (tmp, dirs, options) = fixture();
+        let input = frame();
+        write_cached_media(
+            tmp.path(),
+            &input.full_stem,
+            ".img",
+            &bytes_from_hex(PYTHON_REFERENCE_PKV2_HEX),
+        );
+
+        let report =
+            resolve_media_frames_with_fetcher(CHAT_ID, &[input], &dirs, &options, |_, _| {
+                panic!("cdn should not be called when full cache exists")
+            })
+            .expect("resolve");
+
+        assert!(report.errors.is_empty());
+        assert_eq!(report.tier_counts.get("full"), Some(&1));
+        let record = &report.records[0];
+        assert_eq!(record.tier, MediaTier::Full);
+        assert_eq!(record.tier_reason, "decrypted");
+        assert_eq!(record.sha1.as_deref(), Some(VECTOR_IMAGE_SHA1));
+        assert_eq!(
+            std::fs::read(record.path.as_ref().expect("path")).expect("image"),
+            bytes_from_hex(VECTOR_IMAGE_HEX)
+        );
+    }
+
+    #[test]
+    fn resolves_cdn_after_full_cache_miss_and_verifies_sha1() {
+        let (_, dirs, mut options) = fixture();
+        let mut input = frame();
+        input.cdn_url = Some("https://cdn.example/image?expires=1900000000".to_string());
+        let body = bytes_from_hex(VECTOR_IMAGE_HEX);
+
+        let report = resolve_media_frames_with_fetcher(
+            CHAT_ID,
+            &[input],
+            &dirs,
+            &options,
+            |url, timeout| {
+                assert_eq!(url, "https://cdn.example/image?expires=1900000000");
+                assert_eq!(timeout, DEFAULT_CDN_TIMEOUT);
+                Ok(body.clone())
+            },
+        )
+        .expect("resolve");
+
+        assert!(report.errors.is_empty());
+        assert_eq!(report.records[0].tier, MediaTier::Cdn);
+        assert_eq!(report.records[0].tier_reason, "full-not-cached+cdn-fetched");
+        assert_eq!(report.records[0].sha1.as_deref(), Some(VECTOR_IMAGE_SHA1));
+        options.cdn_enabled = false;
+    }
+
+    #[test]
+    fn cdn_sha1_mismatch_records_error_then_uses_thumbnail() {
+        let (tmp, dirs, mut options) = fixture();
+        let mut input = frame();
+        input.checksum_sha1 = Some("0000000000000000000000000000000000000000".to_string());
+        input.cdn_url = Some("https://cdn.example/image?expires=1900000000&secret=x".to_string());
+        write_cached_media(
+            tmp.path(),
+            &input.thumb_stem,
+            ".thm",
+            &bytes_from_hex(PYTHON_REFERENCE_PKV2_HEX),
+        );
+        options.cdn_timeout = Duration::from_secs(3);
+
+        let report =
+            resolve_media_frames_with_fetcher(CHAT_ID, &[input], &dirs, &options, |_, timeout| {
+                assert_eq!(timeout, Duration::from_secs(3));
+                Ok(bytes_from_hex(VECTOR_IMAGE_HEX))
+            })
+            .expect("resolve");
+
+        assert_eq!(report.records[0].tier, MediaTier::Thumb);
+        assert_eq!(report.records[0].tier_reason, "full-not-cached+cdn-failed");
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(report.errors[0].stage, "cdn");
+        assert_eq!(report.errors[0].path, "https://cdn.example/image");
+        assert!(report.errors[0].error.contains("cdn body sha1 != cs"));
+    }
+
+    #[test]
+    fn no_cdn_mode_never_calls_network_and_emits_stub() {
+        let (_, dirs, options) = fixture();
+        let mut options = MediaResolveOptions::no_cdn(options.output_dir);
+        options.now_epoch = 1_700_000_000;
+        let mut input = frame();
+        input.cdn_url = Some("https://cdn.example/image?expires=1900000000".to_string());
+        let calls = Rc::new(Cell::new(0));
+        let call_count = Rc::clone(&calls);
+
+        let report =
+            resolve_media_frames_with_fetcher(CHAT_ID, &[input], &dirs, &options, move |_, _| {
+                call_count.set(call_count.get() + 1);
+                Ok(Vec::new())
+            })
+            .expect("resolve");
+
+        assert_eq!(calls.get(), 0);
+        assert!(report.errors.is_empty());
+        assert_eq!(report.records[0].tier, MediaTier::Stub);
+        assert_eq!(report.records[0].tier_reason, "not-cached");
+        assert_eq!(report.records[0].path, None);
+        assert_eq!(report.records[0].sha1, None);
+    }
+
+    #[test]
+    fn full_decrypt_failure_records_error_and_returns_decrypt_failed_stub() {
+        let (tmp, dirs, options) = fixture();
+        let input = frame();
+        write_cached_media(tmp.path(), &input.full_stem, ".img", b"not-pkv2");
+
+        let report =
+            resolve_media_frames_with_fetcher(CHAT_ID, &[input], &dirs, &options, |_, _| {
+                panic!("cdn should not be called without url")
+            })
+            .expect("resolve");
+
+        assert_eq!(report.records[0].tier, MediaTier::Stub);
+        assert_eq!(report.records[0].tier_reason, "decrypt-failed");
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(report.errors[0].stage, "full");
+        assert!(report.errors[0].error.contains("not a Pkv2 file"));
+    }
+
+    #[test]
+    fn expired_cdn_url_falls_through_without_fetching() {
+        let (_, dirs, mut options) = fixture();
+        let mut input = frame();
+        input.cdn_url = Some("https://cdn.example/image?expires=1000".to_string());
+        let calls = Rc::new(Cell::new(0));
+        let call_count = Rc::clone(&calls);
+
+        let report =
+            resolve_media_frames_with_fetcher(CHAT_ID, &[input], &dirs, &options, move |_, _| {
+                call_count.set(call_count.get() + 1);
+                Ok(Vec::new())
+            })
+            .expect("resolve");
+
+        assert_eq!(calls.get(), 0);
+        assert_eq!(report.records[0].tier, MediaTier::Stub);
+        assert_eq!(report.records[0].tier_reason, "not-cached+cdn-expired");
+        options.cdn_enabled = false;
+    }
+}

--- a/src/kakao/mod.rs
+++ b/src/kakao/mod.rs
@@ -9,6 +9,10 @@
 pub mod auth;
 mod bplist;
 pub mod derive;
+pub mod media_crypto;
+pub mod media_paths;
+pub mod media_reader;
+pub mod media_resolver;
 pub mod reader;
 
 use std::path::PathBuf;
@@ -16,6 +20,7 @@ use std::path::PathBuf;
 use crate::{Error, Result};
 
 pub use auth::{probe_status, AuthOptions, ProbeStatus, ResolvedAuth};
+pub use media_reader::{read_media_frames_with_options, MediaQuery};
 pub use reader::{ChatRecord, ReaderOutput};
 
 /// Resolve auth and read every openable KakaoTalk database for `home`/`data_dir`.

--- a/src/kakao/reader.rs
+++ b/src/kakao/reader.rs
@@ -61,7 +61,7 @@ pub fn probe_database(path: &Path, key: &str) -> Result<bool> {
     }
 }
 
-fn open_database(path: &Path, key: &str) -> Result<Connection> {
+pub(crate) fn open_database(path: &Path, key: &str) -> Result<Connection> {
     let conn = Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,

--- a/tests/cli_behaviors.rs
+++ b/tests/cli_behaviors.rs
@@ -16,6 +16,20 @@ fn cli_help_identifies_katok_when_invoked() {
 }
 
 #[test]
+fn cli_media_get_help_documents_image_extraction_flags() {
+    let mut cmd = Command::cargo_bin("katok").expect("katok binary");
+    cmd.args(["media", "get", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("media get"))
+        .stdout(predicate::str::contains("--chat"))
+        .stdout(predicate::str::contains("--log"))
+        .stdout(predicate::str::contains("--out"))
+        .stdout(predicate::str::contains("--no-cdn"))
+        .stdout(predicate::str::contains("--json"));
+}
+
+#[test]
 fn cli_reports_macos_permission_panes_without_opening_settings_when_dry_run() {
     let mut cmd = Command::cargo_bin("katok").expect("katok binary");
     cmd.args([

--- a/tests/media_synthetic_db.rs
+++ b/tests/media_synthetic_db.rs
@@ -1,0 +1,411 @@
+//! Synthetic media extraction tests: build an encrypted KakaoTalk-like DB and
+//! local media cache, then drive the native media reader plus resolver. No real
+//! KakaoTalk files, network, or user data are touched.
+
+use std::cell::Cell;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::time::Duration;
+
+use aes::Aes256;
+use cbc::cipher::{block_padding::Pkcs7, BlockEncryptMut, KeyIvInit};
+use katok::kakao::{
+    auth, derive,
+    media_paths::{
+        album_full_stem, album_thumb_stem, chat_media_dir_name, photo_full_stem, photo_thumb_stem,
+        MediaDirs,
+    },
+    media_resolver::{
+        resolve_media_frames_with_fetcher, MediaRecord, MediaResolveOptions, MediaTier,
+    },
+    read_media_frames_with_options, AuthOptions, MediaQuery,
+};
+use rusqlite::{params, Connection};
+use sha1::{Digest as Sha1Digest, Sha1};
+use sha2::Sha256;
+
+const TEST_UUID: &str = "00000000-1111-2222-3333-444444444444";
+const TEST_USER_ID: i64 = 1_000_000_001;
+const CHAT_ID: i64 = 1_234_567_890_123;
+const AUTHOR_ID: i64 = 500;
+const MEDIA_ACCOUNT: &str = "0123456789abcdef0123456789abcdef01234567";
+
+const LOG_FULL: i64 = 10_001;
+const LOG_CDN: i64 = 10_002;
+const LOG_THUMB_AFTER_CDN_MISMATCH: i64 = 10_003;
+const LOG_STUB: i64 = 10_004;
+const LOG_ALBUM: i64 = 10_005;
+
+const CDN_URL: &str = "https://cdn.example/full.jpg?expires=1900000000";
+const MISMATCH_URL: &str = "https://cdn.example/mismatch.jpg?expires=1900000000&secret=redacted";
+
+const FULL_IMAGE: &[u8] = b"\xff\xd8\xff\xe0KATOK-FULL\xff\xd9";
+const CDN_IMAGE: &[u8] = b"\xff\xd8\xff\xe0KATOK-CDN\xff\xd9";
+const THUMB_IMAGE: &[u8] = b"\xff\xd8\xff\xe0KATOK-THUMB\xff\xd9";
+const ALBUM_FULL_IMAGE: &[u8] = b"\xff\xd8\xff\xe0KATOK-ALBUM-FULL\xff\xd9";
+const ALBUM_THUMB_IMAGE: &[u8] = b"\xff\xd8\xff\xe0KATOK-ALBUM-THUMB\xff\xd9";
+const WRONG_CDN_IMAGE: &[u8] = b"\xff\xd8\xff\xe0KATOK-WRONG-CDN\xff\xd9";
+
+type Aes256CbcEncryptor = cbc::Encryptor<Aes256>;
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    home: PathBuf,
+    data_dir: PathBuf,
+    media_dirs: MediaDirs,
+    output_dir: PathBuf,
+}
+
+fn open_with_schema(path: &Path, key: &str) -> Connection {
+    let conn = Connection::open(path).expect("open writable db");
+    conn.execute_batch(&format!(
+        "PRAGMA key = '{key}'; PRAGMA cipher_compatibility = 3;"
+    ))
+    .expect("apply cipher key");
+    conn.execute_batch(
+        "CREATE TABLE NTChatMessage (
+            chatId INTEGER NOT NULL DEFAULT 0,
+            logId INTEGER NOT NULL DEFAULT 0,
+            msgId INTEGER NOT NULL DEFAULT 0,
+            authorId INTEGER NOT NULL DEFAULT 0,
+            type INTEGER NOT NULL DEFAULT -1,
+            sentAt INTEGER DEFAULT 0,
+            attachment TEXT,
+            supplement TEXT,
+            message TEXT,
+            PRIMARY KEY (chatId, logId, msgId)
+        );",
+    )
+    .expect("create media schema");
+    conn
+}
+
+fn create_fixture() -> Fixture {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let home = tmp.path().join("home");
+    let data_dir = tmp.path().join("data");
+    let output_dir = tmp.path().join("out");
+    std::fs::create_dir_all(&data_dir).expect("data dir");
+
+    let container = auth::container_dir(&home);
+    std::fs::create_dir_all(&container).expect("container dir");
+    let key = derive::secure_key(TEST_USER_ID, TEST_UUID);
+    let db_path = container.join(derive::database_name(TEST_USER_ID, TEST_UUID));
+    let conn = open_with_schema(&db_path, &key);
+    insert_media_rows(&conn);
+    drop(conn);
+
+    let account = container.join(MEDIA_ACCOUNT);
+    let media_dirs = MediaDirs::from_roots_for_test(vec![account.clone()]);
+    write_cached_media(
+        &account,
+        LOG_FULL,
+        &photo_full_stem(LOG_FULL),
+        ".img",
+        FULL_IMAGE,
+        1,
+    );
+    write_cached_media(
+        &account,
+        LOG_THUMB_AFTER_CDN_MISMATCH,
+        &photo_thumb_stem(LOG_THUMB_AFTER_CDN_MISMATCH),
+        ".thm",
+        THUMB_IMAGE,
+        2,
+    );
+    write_cached_media(
+        &account,
+        LOG_ALBUM,
+        &album_full_stem(LOG_ALBUM, 0),
+        ".img",
+        ALBUM_FULL_IMAGE,
+        3,
+    );
+    write_cached_media(
+        &account,
+        LOG_ALBUM,
+        &album_thumb_stem(LOG_ALBUM, 1),
+        ".thm",
+        ALBUM_THUMB_IMAGE,
+        4,
+    );
+
+    Fixture {
+        _tmp: tmp,
+        home,
+        data_dir,
+        media_dirs,
+        output_dir,
+    }
+}
+
+fn insert_media_rows(conn: &Connection) {
+    insert_photo(
+        conn,
+        LOG_FULL,
+        1,
+        1_700_000_001,
+        FULL_IMAGE,
+        Some("https://cdn.example/unused.jpg?expires=1900000000"),
+    );
+    insert_photo(conn, LOG_CDN, 2, 1_700_000_002, CDN_IMAGE, Some(CDN_URL));
+    insert_photo(
+        conn,
+        LOG_THUMB_AFTER_CDN_MISMATCH,
+        3,
+        1_700_000_003,
+        THUMB_IMAGE,
+        Some(MISMATCH_URL),
+    );
+    insert_photo(conn, LOG_STUB, 4, 1_700_000_004, FULL_IMAGE, None);
+
+    let attachment = serde_json::json!({
+        "wl": [320, 640],
+        "hl": [240, 480],
+        "csl": [sha1_hex(ALBUM_FULL_IMAGE), sha1_hex(ALBUM_THUMB_IMAGE)],
+        "imageUrls": [null, null]
+    })
+    .to_string();
+    conn.execute(
+        "INSERT INTO NTChatMessage(chatId, logId, msgId, authorId, type, sentAt, attachment, supplement, message)
+         VALUES (?1, ?2, ?3, ?4, 27, ?5, ?6, NULL, '')",
+        params![CHAT_ID, LOG_ALBUM, 5_i64, AUTHOR_ID, 1_700_000_005_i64, attachment],
+    )
+    .expect("insert album row");
+}
+
+fn insert_photo(
+    conn: &Connection,
+    log_id: i64,
+    msg_id: i64,
+    sent_at: i64,
+    image: &[u8],
+    url: Option<&str>,
+) {
+    let attachment = serde_json::json!({
+        "w": 640,
+        "h": 480,
+        "cs": sha1_hex(image),
+        "url": url
+    })
+    .to_string();
+    conn.execute(
+        "INSERT INTO NTChatMessage(chatId, logId, msgId, authorId, type, sentAt, attachment, supplement, message)
+         VALUES (?1, ?2, ?3, ?4, 2, ?5, ?6, NULL, '')",
+        params![CHAT_ID, log_id, msg_id, AUTHOR_ID, sent_at, attachment],
+    )
+    .expect("insert photo row");
+}
+
+fn auth_options(fixture: &Fixture) -> AuthOptions {
+    AuthOptions {
+        home: fixture.home.clone(),
+        data_dir: fixture.data_dir.clone(),
+        user_id_override: Some(TEST_USER_ID),
+        uuid_override: Some(TEST_UUID.to_string()),
+        max_user_id: 0,
+    }
+}
+
+fn media_query(log_id: Option<i64>) -> MediaQuery {
+    MediaQuery {
+        chat_id: CHAT_ID,
+        log_id,
+        limit: 100,
+    }
+}
+
+fn resolve_options(output_dir: PathBuf) -> MediaResolveOptions {
+    let mut options = MediaResolveOptions::new(output_dir);
+    options.now_epoch = 1_700_000_000;
+    options
+}
+
+fn write_cached_media(
+    account: &Path,
+    log_id: i64,
+    stem: &str,
+    ext: &str,
+    image: &[u8],
+    iv_seed: u8,
+) {
+    let path = account
+        .join(chat_media_dir_name(CHAT_ID))
+        .join(format!("{stem}{ext}"));
+    std::fs::create_dir_all(path.parent().expect("cache parent")).expect("cache dir");
+    std::fs::write(path, pkv2_image(image, log_id, iv_seed)).expect("cached pkv2 media");
+}
+
+fn pkv2_image(image: &[u8], log_id: i64, iv_seed: u8) -> Vec<u8> {
+    let mut plaintext = vec![b'K'; 256];
+    plaintext.extend_from_slice(image);
+    let key_string: String = format!("#{log_id}%").chars().rev().collect();
+    let aes_key = Sha256::digest(key_string.as_bytes());
+    let iv = [iv_seed; 16];
+    let mut buf = vec![0_u8; plaintext.len() + 16];
+    buf[..plaintext.len()].copy_from_slice(&plaintext);
+    let ciphertext = Aes256CbcEncryptor::new_from_slices(&aes_key, &iv)
+        .expect("aes init")
+        .encrypt_padded_mut::<Pkcs7>(&mut buf, plaintext.len())
+        .expect("pkcs7 encrypt")
+        .to_vec();
+    let mut out = b"Pkv2".to_vec();
+    out.extend_from_slice(&iv);
+    out.extend_from_slice(&ciphertext);
+    out
+}
+
+fn sha1_hex(bytes: &[u8]) -> String {
+    let digest = Sha1::digest(bytes);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn record(
+    report: &katok::kakao::media_resolver::MediaReport,
+    log_id: i64,
+    idx: usize,
+) -> &MediaRecord {
+    report
+        .records
+        .iter()
+        .find(|record| record.log_id == log_id && record.idx == idx)
+        .unwrap_or_else(|| panic!("missing record log_id={log_id} idx={idx}"))
+}
+
+#[test]
+fn synthetic_db_media_pipeline_resolves_full_cdn_thumb_stub_and_album_frames() {
+    let fixture = create_fixture();
+    let frames = read_media_frames_with_options(&auth_options(&fixture), &media_query(None))
+        .expect("read frames");
+
+    assert_eq!(frames.len(), 6);
+    assert!(frames
+        .iter()
+        .any(|frame| frame.log_id == LOG_ALBUM && frame.idx == 1 && frame.width == Some(640)));
+
+    let fetch_calls = Rc::new(Cell::new(0));
+    let calls = Rc::clone(&fetch_calls);
+    let report = resolve_media_frames_with_fetcher(
+        CHAT_ID,
+        &frames,
+        &fixture.media_dirs,
+        &resolve_options(fixture.output_dir.clone()),
+        move |url, timeout| {
+            calls.set(calls.get() + 1);
+            assert_eq!(timeout, Duration::from_secs(20));
+            match url {
+                CDN_URL => Ok(CDN_IMAGE.to_vec()),
+                MISMATCH_URL => Ok(WRONG_CDN_IMAGE.to_vec()),
+                other => panic!("unexpected CDN url {other}"),
+            }
+        },
+    )
+    .expect("resolve media");
+
+    assert_eq!(fetch_calls.get(), 2);
+    assert_eq!(report.tier_counts.get("full"), Some(&2));
+    assert_eq!(report.tier_counts.get("cdn"), Some(&1));
+    assert_eq!(report.tier_counts.get("thumb"), Some(&2));
+    assert_eq!(report.tier_counts.get("stub"), Some(&1));
+
+    let full = record(&report, LOG_FULL, 0);
+    assert_eq!(full.tier, MediaTier::Full);
+    assert_eq!(full.tier_reason, "decrypted");
+    assert_eq!(full.sha1.as_deref(), Some(sha1_hex(FULL_IMAGE).as_str()));
+    assert_eq!(
+        std::fs::read(full.path.as_ref().expect("full path")).expect("full output"),
+        FULL_IMAGE
+    );
+
+    let cdn = record(&report, LOG_CDN, 0);
+    assert_eq!(cdn.tier, MediaTier::Cdn);
+    assert_eq!(cdn.tier_reason, "full-not-cached+cdn-fetched");
+    assert_eq!(cdn.sha1.as_deref(), Some(sha1_hex(CDN_IMAGE).as_str()));
+    assert_eq!(
+        std::fs::read(cdn.path.as_ref().expect("cdn path")).expect("cdn output"),
+        CDN_IMAGE
+    );
+
+    let thumb = record(&report, LOG_THUMB_AFTER_CDN_MISMATCH, 0);
+    assert_eq!(thumb.tier, MediaTier::Thumb);
+    assert_eq!(thumb.tier_reason, "full-not-cached+cdn-failed");
+    assert_eq!(thumb.sha1.as_deref(), Some(sha1_hex(THUMB_IMAGE).as_str()));
+    assert_eq!(
+        std::fs::read(thumb.path.as_ref().expect("thumb path")).expect("thumb output"),
+        THUMB_IMAGE
+    );
+
+    let stub = record(&report, LOG_STUB, 0);
+    assert_eq!(stub.tier, MediaTier::Stub);
+    assert_eq!(stub.tier_reason, "not-cached");
+    assert_eq!(stub.path, None);
+    assert_eq!(stub.sha1, None);
+
+    let album_full = record(&report, LOG_ALBUM, 0);
+    assert_eq!(album_full.tier, MediaTier::Full);
+    assert_eq!(
+        album_full.sha1.as_deref(),
+        Some(sha1_hex(ALBUM_FULL_IMAGE).as_str())
+    );
+    assert_eq!(
+        album_full.path.as_ref().unwrap().file_name().unwrap(),
+        "10005_0.jpg"
+    );
+
+    let album_thumb = record(&report, LOG_ALBUM, 1);
+    assert_eq!(album_thumb.tier, MediaTier::Thumb);
+    assert_eq!(album_thumb.tier_reason, "full-not-cached");
+    assert_eq!(
+        album_thumb.path.as_ref().unwrap().file_name().unwrap(),
+        "10005_1_thumb.jpg"
+    );
+    assert_eq!(
+        album_thumb.sha1.as_deref(),
+        Some(sha1_hex(ALBUM_THUMB_IMAGE).as_str())
+    );
+
+    assert_eq!(report.errors.len(), 1);
+    assert_eq!(report.errors[0].stage, "cdn");
+    assert_eq!(report.errors[0].log_id, LOG_THUMB_AFTER_CDN_MISMATCH);
+    assert_eq!(report.errors[0].path, "https://cdn.example/mismatch.jpg");
+    assert!(report.errors[0].error.contains("cdn body sha1 != cs"));
+}
+
+#[test]
+fn synthetic_db_no_cdn_mode_is_pure_local_and_degrades_to_stub() {
+    let fixture = create_fixture();
+    let frames =
+        read_media_frames_with_options(&auth_options(&fixture), &media_query(Some(LOG_CDN)))
+            .expect("read one CDN frame");
+    assert_eq!(frames.len(), 1);
+
+    let mut options = MediaResolveOptions::no_cdn(fixture.output_dir.clone());
+    options.now_epoch = 1_700_000_000;
+    let fetch_calls = Rc::new(Cell::new(0));
+    let calls = Rc::clone(&fetch_calls);
+    let report = resolve_media_frames_with_fetcher(
+        CHAT_ID,
+        &frames,
+        &fixture.media_dirs,
+        &options,
+        move |_, _| {
+            calls.set(calls.get() + 1);
+            Ok(Vec::new())
+        },
+    )
+    .expect("resolve no-cdn");
+
+    assert_eq!(fetch_calls.get(), 0);
+    assert!(report.errors.is_empty());
+    assert_eq!(report.tier_counts.get("stub"), Some(&1));
+    let cdn_disabled = record(&report, LOG_CDN, 0);
+    assert_eq!(cdn_disabled.tier, MediaTier::Stub);
+    assert_eq!(cdn_disabled.tier_reason, "not-cached");
+    assert_eq!(cdn_disabled.path, None);
+}


### PR DESCRIPTION
## Summary

이 PR은 macOS KakaoTalk 이미지 메시지를 로컬에서 추출하는 `katok media get` 서브커맨드를 추가합니다.

- type 2 단일 사진과 type 27 앨범 프레임을 읽습니다.
- `Pkv2` AES 이미지 복호를 Rust로 구현했습니다.
- tier 순서는 로컬 full `.img`, CDN presigned GET, 로컬 thumbnail `.thm`, stub입니다.
- `--no-cdn`으로 CDN tier를 끄고 로컬 파일과 stub만 사용합니다.

## Local-first and privacy

- 실제 대화 본문은 출력하지 않고 이미지 attachment metadata만 읽습니다.
- 기본 출력 위치는 katok data directory 아래 `media/<chat-id>/`입니다.
- 이미지 추출은 사용자가 `media get`을 직접 실행해야 동작합니다.
- 이 명령에서 네트워크를 사용할 수 있는 유일한 동작은 attachment metadata에 포함된 CDN presigned GET입니다.
- CDN 응답은 attachment의 `cs` SHA-1과 일치할 때만 저장합니다. 일치하지 않으면 파일을 저장하지 않고 다음 tier로 내려갑니다.
- `--no-cdn`을 주면 CDN tier를 완전히 비활성화합니다.

## Implementation

- `src/kakao/media_crypto.rs`: Pkv2 AES-256-CBC 복호 helper.
- `src/kakao/media_paths.rs`: media account dir 스캔과 cryptName 경로 조립.
- `src/kakao/media_reader.rs`: `NTChatMessage` type 2/27 attachment를 frame 단위로 정규화.
- `src/kakao/media_resolver.rs`: full/CDN/thumb/stub 4-tier resolver.
- `src/cli.rs`, `src/commands.rs`, `src/commands/media_commands.rs`: CLI 배선.

## Verification

로컬에서 실행한 명령:

```bash
cargo test
cargo clippy -- -D warnings
cargo run -- media get --help
```

추가한 커버리지:

- Pkv2 Rust 복호 결과가 참조 벡터와 byte-for-byte 일치.
- 로컬 full `.img` tier가 복호 bytes와 일치하는 SHA-1을 기록.
- CDN tier는 SHA-1 검증된 bytes만 저장.
- CDN SHA-1 불일치 시 thumbnail로 강등.
- `--no-cdn`은 fetcher를 호출하지 않음.
- thumbnail `.thm` tier와 stub tier가 `tier_reason`으로 관측됨.
- Album type 27이 여러 frame record를 생성.

테스트는 합성 SQLCipher DB와 합성 Pkv2 fixture만 사용하며 실제 대화 데이터를 포함하지 않습니다.

## Not included

영상, 음성, 일반 파일 추출은 이 PR 범위가 아닙니다(이미지 먼저).
