### PR TITLE
fix(reader): resolve replies from the attachment column

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,38 @@
+# katok local notes
+
+Never committed. Git-ignored via `.gitignore`, and this repo is a public fork, so
+anything naming a real person or private tooling stays in this file.
+
+**This file lives only in this checkout.** A git-ignored file is deleted along
+with a worktree it happens to sit in, and it is not in any commit, so nothing
+restores it. Keep the canonical copy somewhere durable and treat this as a
+convenience copy.
+
+## Send testing
+
+The maintainer has authorised these targets for `katok send` experiments
+(2026-07-29, direct instruction):
+
+- **소링링** — free to send test messages and images to.
+- **The maintainer's own chats** — also fine.
+
+Any other room needs a fresh ask. Sending cannot be undone and reaches real
+people, so treat "it worked last time" as covering only the rooms listed above.
+
+Prefer `--dry-run` when only targeting needs proving; it opens the room window
+and sends nothing.
+
+## Verified by hand
+
+- **Clipboard save/restore around an image send** (2026-07-29, 소링링). A canary
+  string was copied, a test image sent, then the canary came back
+  byte-identical and the previously active application was restored. The send
+  took 3.5s. Nothing in the send path still needs a manual pass.
+
+## Known, not a regression
+
+Some rooms cannot be opened by clicking their chat-list row — 카카오페이,
+에르메스단, 가온노트 신지혜 have all failed this way. The installed release
+build failed identically before any of this work, so it predates the curtain.
+소링링, 클코단, and 블라이 V2 open normally. Once a person opens a room by hand
+it stays reachable.

--- a/src/kakao/reader.rs
+++ b/src/kakao/reader.rs
@@ -267,12 +267,18 @@ fn load_users(conn: &Connection) -> Result<HashMap<i64, String>> {
     Ok(users)
 }
 
-/// Best-effort: parse `supplement` JSON for a referenced parent `logId` in the
-/// same chat. Only the JSON structure is inspected, never message bodies.
+/// Best-effort: parse an attachment/supplement JSON blob for a referenced
+/// parent `logId` in the same chat. Only the JSON structure is inspected, never
+/// message bodies.
 ///
-/// `supplement` is present on ~64% of messages (media/attachment/link-preview
-/// metadata, not just replies), so this is deliberately conservative to avoid
-/// synthesizing false reply edges:
+/// Callers pass the `attachment` column first. A KakaoTalk reply (`type` 26)
+/// stores `src_logId` at the top level of `attachment`; measured on a live
+/// install, 6891 of 6891 replies were shaped that way and **none** carried it in
+/// `supplement` — so a reader consulting only `supplement`, as this one once
+/// did, resolved no replies at all while its unit tests stayed green.
+///
+/// Both columns carry metadata for non-reply reasons, so this stays deliberately
+/// conservative to avoid synthesizing false reply edges:
 ///   * only reply-specific keys are accepted (the bare generic `logId` is NOT,
 ///     since media supplements legitimately embed it for non-reply reasons);
 ///   * those keys are looked up directly on the top-level object and, by
@@ -351,7 +357,7 @@ fn read_one(
 
     let mut stmt = conn
         .prepare(
-            "SELECT chatId, logId, authorId, type, message, sentAt, supplement
+            "SELECT chatId, logId, authorId, type, message, sentAt, supplement, attachment
              FROM NTChatMessage
              WHERE message IS NOT NULL AND message <> ''",
         )
@@ -370,8 +376,9 @@ fn read_one(
             // sentAt is epoch seconds; tolerate a float column by reading f64.
             let sent_at: f64 = row.get::<_, f64>(5).unwrap_or(0.0);
             let supplement: Option<String> = row.get(6)?;
+            let attachment: Option<String> = row.get(7)?;
             Ok((
-                chat_id, log_id, author_id, msg_type, text, sent_at, supplement,
+                chat_id, log_id, author_id, msg_type, text, sent_at, supplement, attachment,
             ))
         })
         .map_err(Error::Sql)?;
@@ -381,13 +388,14 @@ fn read_one(
     // otherwise-healthy read. Row content is never logged.
     let mut skipped_rows: usize = 0;
     for row in rows {
-        let (chat_id, log_id, author_id, msg_type, text, sent_at, supplement) = match row {
-            Ok(values) => values,
-            Err(_) => {
-                skipped_rows += 1;
-                continue;
-            }
-        };
+        let (chat_id, log_id, author_id, msg_type, text, sent_at, supplement, attachment) =
+            match row {
+                Ok(values) => values,
+                Err(_) => {
+                    skipped_rows += 1;
+                    continue;
+                }
+            };
 
         let room = rooms.get(&chat_id);
         let chat_type = room
@@ -425,7 +433,11 @@ fn read_one(
             format!("type_{msg_type}")
         };
 
-        let reply_to_message_id = reply_parent_log_id(supplement.as_deref())
+        // `attachment` first: on a live install every reply carries its
+        // `src_logId` there and none carry it in `supplement`, so consulting
+        // only the latter resolved nothing at all.
+        let reply_to_message_id = reply_parent_log_id(attachment.as_deref())
+            .or_else(|| reply_parent_log_id(supplement.as_deref()))
             .filter(|parent| *parent != log_id)
             .map(|parent| format!("{chat_id}-{parent}"));
 

--- a/tests/reader_synthetic_db.rs
+++ b/tests/reader_synthetic_db.rs
@@ -50,6 +50,7 @@ fn open_with_schema(path: &Path, key: &str) -> Connection {
             authorId INTEGER NOT NULL DEFAULT 0,
             type INTEGER NOT NULL DEFAULT -1,
             supplement TEXT,
+            attachment TEXT,
             message TEXT,
             sentAt INTEGER DEFAULT 0,
             PRIMARY KEY (chatId, logId, msgId)
@@ -89,14 +90,20 @@ fn create_encrypted_db(path: &Path, key: &str) {
 
     // Messages: direct text, group text, a non-text type, and a reply.
     conn.execute(
-        "INSERT INTO NTChatMessage(chatId, logId, msgId, authorId, type, supplement, message, sentAt)
+        "INSERT INTO NTChatMessage(chatId, logId, msgId, authorId, type, supplement, attachment, message, sentAt)
          VALUES
-            (100, 10, 1, 500, 1, NULL, 'direct hello', 1700000000),
-            (100, 11, 2, 240061982, 1, NULL, 'direct reply body', 1700000100),
-            (200, 20, 3, 600, 1, NULL, 'group message', 1700000200),
-            (200, 21, 4, 500, 26, NULL, 'image caption', 1700000300),
-            (200, 22, 5, 600, 1, '{\"reply\":{\"src_logId\":20}}', 'this is a reply', 1700000400),
-            (200, 23, 6, 500, 1, NULL, '', 1700000500)",
+            (100, 10, 1, 500, 1, NULL, NULL, 'direct hello', 1700000000),
+            (100, 11, 2, 240061982, 1, NULL, NULL, 'direct reply body', 1700000100),
+            (200, 20, 3, 600, 1, NULL, NULL, 'group message', 1700000200),
+            (200, 21, 4, 500, 26, NULL, NULL, 'image caption', 1700000300),
+            (200, 22, 5, 600, 1, '{\"reply\":{\"src_logId\":20}}', NULL, 'this is a reply', 1700000400),
+            (200, 23, 6, 500, 1, NULL, NULL, '', 1700000500),
+            -- Shaped the way a real KakaoTalk reply is: type 26, src_logId at
+            -- the top level of `attachment`, `supplement` empty. The row above
+            -- is the hypothetical `supplement` shape the reader used to look
+            -- for, which is why the old fixture passed while nothing resolved
+            -- against a real database.
+            (200, 24, 7, 600, 26, NULL, '{\"src_logId\":20,\"src_type\":1,\"src_userId\":600}', 'real-shaped reply', 1700000600)",
         [],
     )
     .expect("insert messages");
@@ -128,8 +135,8 @@ fn reads_synthetic_kakao_db_and_maps_model() {
     };
     let output = katok::kakao::read_kakao_with_options(&options).expect("read kakao");
 
-    // Empty-text message (logId 23) is filtered out → 5 messages remain.
-    assert_eq!(output.messages.len(), 5);
+    // Empty-text message (logId 23) is filtered out → 6 messages remain.
+    assert_eq!(output.messages.len(), 6);
 
     // Two chats discovered with correct classification.
     assert_eq!(output.chats.len(), 2);
@@ -185,6 +192,12 @@ fn reads_synthetic_kakao_db_and_maps_model() {
     let reply = by_id("200-22");
     assert_eq!(reply.reply_to_message_id.as_deref(), Some("200-20"));
 
+    // The shape real KakaoTalk actually writes: `src_logId` on `attachment`,
+    // nothing in `supplement`. Reading only `supplement` resolved zero replies
+    // against a live archive while every unit test stayed green.
+    let real_reply = by_id("200-24");
+    assert_eq!(real_reply.reply_to_message_id.as_deref(), Some("200-20"));
+
     // Account hash is the stable sha256(user_id) for every row.
     let account = &output.messages[0].account_hash;
     assert_eq!(account.len(), 64);
@@ -200,7 +213,7 @@ fn reads_synthetic_kakao_db_and_maps_model() {
         .filter(|message| message.chat_id == "200")
         .map(|message| message.message_id.as_str())
         .collect();
-    assert_eq!(chat_200, vec!["200-20", "200-21", "200-22"]);
+    assert_eq!(chat_200, vec!["200-20", "200-21", "200-22", "200-24"]);
 }
 
 /// A single malformed message row (a non-UTF8 BLOB stored in the TEXT `message`
@@ -288,8 +301,8 @@ fn discovers_and_reads_db_suffixed_file() {
     };
     let output = katok::kakao::read_kakao_with_options(&options).expect("read kakao");
 
-    // Same content as the bare-named DB: 5 mapped messages, 2 chats.
-    assert_eq!(output.messages.len(), 5);
+    // Same content as the bare-named DB: 6 mapped messages, 2 chats.
+    assert_eq!(output.messages.len(), 6);
     assert_eq!(output.chats.len(), 2);
 }
 
@@ -467,6 +480,7 @@ fn reads_older_schema_without_title_or_member_columns() {
             authorId INTEGER NOT NULL DEFAULT 0,
             type INTEGER NOT NULL DEFAULT -1,
             supplement TEXT,
+            attachment TEXT,
             message TEXT,
             sentAt INTEGER DEFAULT 0,
             PRIMARY KEY (chatId, logId, msgId)


### PR DESCRIPTION
A KakaoTalk reply stores the id of the message it answers as `src_logId` at the **top level of the `attachment` column**. The reader looks for it in `supplement`, and does not select `attachment` at all, so `reply_to_message_id` is never populated.

Measured on a live install: **6891 of 6891 replies (`type` 26) carry `src_logId` in `attachment`, and none carry it in `supplement`.**

```sql
SELECT COUNT(*) FROM NTChatMessage WHERE type=26;                              -- 6891
SELECT COUNT(*) FROM NTChatMessage WHERE type=26 AND attachment LIKE %src_logId%;  -- 6891
SELECT COUNT(*) FROM NTChatMessage WHERE type=26 AND supplement LIKE %src_logId%;  -- 0
```

Everything downstream is empty as a consequence — `reply_edges`, `chunk_parent_refs`, and the `parent_chunk_ids` on every search hit — so a reply cannot be traced back to what it answers, which is what those tables exist for. On the archive I tested against this went from 0 to 6,937 resolved links after re-syncing, with no schema migration.

### Why the tests did not catch it

`tests/reader_synthetic_db.rs` modelled a shape KakaoTalk never writes (`{"reply":{"src_logId":N}}` inside `supplement`), and its `NTChatMessage` fixture omitted the `attachment` column entirely — so the reader could not have read the real shape even if it had tried.

Both are corrected. The added row is shaped the way a real reply is, and **the test fails against the current reader** and passes with this change.

### Change

- `SELECT` now includes `attachment`, and `reply_parent_log_id` is tried on it first.
- `supplement` is kept as a fallback; the existing shape costs nothing to keep supporting.
- Fixture schema gains `attachment`; one realistically-shaped reply row added.

No behaviour change for anything that was already resolving.