### PR TITLE
feat(katok): update to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.3.1 - 2026-08-12
+
+### Privacy
+
+- Replaced live-derived KakaoTalk identity fixtures with explicit synthetic
+  values and hardened the publication privacy checks.
+- Added a full-history CI and release gate that rejects non-synthetic UUIDs,
+  plausible KakaoTalk user identifiers, derived database-name oracles, and
+  personal home paths in every newly introduced commit, including values
+  removed by a later commit.
+
+### Search and indexing
+
+- Search indexes now recover atomically from orphaned, stale, or corrupt
+  generations while preserving the last committed generation when rebuilding
+  fails.
+- Semantic parent-window loading and bulk index preparation now avoid
+  repeated per-result archive reads.
+
 ## 0.3.0 - 2026-08-02
 
 ### Sending

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "katok"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katok"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT"


### PR DESCRIPTION
## Summary

- publish the privacy-history gate and synthetic fixture remediation
- ship atomic search-index recovery and semantic bulk-loading improvements
- bump the Rust crate to 0.3.1

## Verification

- rustup run 1.91.0 cargo fmt --all -- --check
- rustup run 1.91.0 cargo clippy --all-targets -- -D warnings
- KATOK_EMBEDDER=local-test rustup run 1.91.0 cargo test --all-targets
- rustup run 1.91.0 cargo publish --dry-run
- python3 scripts/verify_release_config.py
- bash tests/verify_history_privacy.sh
- python3 scripts/verify_history_privacy.py . origin/main..HEAD
- cargo run -- --help
- invalid CLI invocation exits non-zero with usage output