### PR TITLE
ci(release): bound history scan to release delta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,21 @@ jobs:
         run: bash tests/verify_history_privacy.sh
 
       - name: Verify Git history privacy
-        run: python3 scripts/verify_history_privacy.py . "${GITHUB_SHA}"
+        shell: bash
+        run: |
+          set -euo pipefail
+          previous_tag="$(
+            git tag --sort=-version:refname |
+              grep -Fxv "${GITHUB_REF_NAME}" |
+              head -n 1
+          )"
+          if [[ -n "${previous_tag}" ]]; then
+            release_base="$(git merge-base "${previous_tag}" "${GITHUB_SHA}")"
+            revision="${release_base}..${GITHUB_SHA}"
+          else
+            revision="${GITHUB_SHA}"
+          fi
+          python3 scripts/verify_history_privacy.py . "${revision}"
 
   binaries:
     name: Build ${{ matrix.target }}

--- a/tests/verify_history_privacy.sh
+++ b/tests/verify_history_privacy.sh
@@ -37,4 +37,23 @@ git -C "${repo}" reflog expire --expire=now --all
 git -C "${repo}" gc --prune=now --quiet
 
 python3 "${root}/scripts/verify_history_privacy.py" "${repo}" HEAD >/dev/null
+
+git -C "${repo}" tag v0.1.0
+mkdir -p "${repo}/docs"
+printf '%s\n' 'release-safe' > "${repo}/docs/release.txt"
+git -C "${repo}" add .
+git -C "${repo}" commit -qm release-safe
+
+git -C "${repo}" branch release-main
+git -C "${repo}" checkout -q --detach v0.1.0
+mkdir -p "${repo}/docs"
+printf '%s\n' 'previous-release' > "${repo}/docs/previous-release.txt"
+git -C "${repo}" add .
+git -C "${repo}" commit -qm previous-release
+git -C "${repo}" tag -f v0.1.0
+git -C "${repo}" checkout -q release-main
+
+release_base="$(git -C "${repo}" merge-base v0.1.0 HEAD)"
+python3 "${root}/scripts/verify_history_privacy.py" \
+  "${repo}" "${release_base}..HEAD" >/dev/null
 echo "ok: history privacy scanner rejects old leaks and accepts rewritten history"


### PR DESCRIPTION
## Summary

- derive the release history scan from the merge-base of the previous version tag and the current tag
- preserve full scanning of every commit introduced since the prior release, even after rewritten release tags diverge from main
- add a synthetic regression for rewritten-tag ancestry

## Root cause

The release workflow passed a single tag SHA to `git rev-list`, which scans every ancestor. After the privacy rewrite, historical release tags are no longer direct ancestors of current main, so validation reached pre-remediation `.omo` commits and blocked publishing.

## Verification

- bash tests/verify_history_privacy.sh
- python3 scripts/verify_history_privacy.py . "$(git merge-base v0.3.0 HEAD)..HEAD"
- python3 scripts/verify_release_config.py