### PR TITLE
feat(katok): update to v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.2 - 2026-08-12
+
+### Release
+
+- Fixed release validation after the repository privacy rewrite by scanning
+  commits from the merge-base of the previous version tag through the current
+  release, rather than rescanning unrelated pre-remediation ancestors.
+
 ## 0.3.1 - 2026-08-12
 
 ### Privacy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "katok"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katok"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT"


### PR DESCRIPTION
## Summary

- publish the v0.3.1 product changes under a new version after the v0.3.1 tag workflow was blocked before publishing
- include the corrected release-history privacy range
- bump the Rust crate to 0.3.2

## Verification

- rustup run 1.91.0 cargo fmt --all -- --check
- rustup run 1.91.0 cargo clippy --all-targets -- -D warnings
- KATOK_EMBEDDER=local-test rustup run 1.91.0 cargo test --all-targets
- rustup run 1.91.0 cargo publish --dry-run
- python3 scripts/verify_release_config.py
- bash tests/verify_history_privacy.sh
- release merge-base history scan
- cargo run -- --help